### PR TITLE
Generate for standalone Ping Federate

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -37,6 +37,9 @@ pipenv install
 To regenerate the APIs and models of the SDK
 
 ```bash
+export <swagger_url>
+export <swagger_version>
+cd src
 make generate
 ```
 

--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ buildRequirements:
 
 generate: ## run the SDK generator
 	$(info [+] Running SDK package generator...)
-	python3 pingfedsdk/generate.py
+	python3 src/generate.py
 .PHONY: generate
 
 docker-generate: ## run the SDK generator

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -42,6 +42,9 @@ class Fetch():
 
         try:
             response = self.session.get(self.swagger_url)
+            if response.status_code == 401 or response.status_code == 404:
+                raise Exception("Invalid swagger url or credentials, this can be as an environment variable, "
+                                "see documentation.")
         except Exception as err:
             err_str = f"Failed to download swagger from: {self.swagger_url} with error {err}"
             self.logger.error(err_str)

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -43,7 +43,7 @@ class Fetch():
         try:
             response = self.session.get(self.swagger_url)
             if response.status_code == 401 or response.status_code == 404:
-                raise Exception("Invalid swagger url or credentials, this can be as an environment variable, "
+                raise Exception("Invalid swagger url or credentials, this can be as set as an environment variable, "
                                 "see documentation.")
         except Exception as err:
             err_str = f"Failed to download swagger from: {self.swagger_url} with error {err}"

--- a/src/generate.py
+++ b/src/generate.py
@@ -131,4 +131,10 @@ class Generate():
 
 
 if __name__ == "__main__":
-    Generate("https://localhost:9999/pf-admin-api/v1/api-docs").generate()
+    swagger_url = os.environ.get(
+        "PING_IDENTITY_SWAGGER_URL", "https://localhost:9999/pf-admin-api/v1/api-docs"
+    )
+    swagger_version = os.environ.get(
+        "PING_IDENTITY_SWAGGER_VERSION", "1.2"
+    )
+    Generate(swagger_url=swagger_url, swagger_version=swagger_version).generate()


### PR DESCRIPTION
- Override the default swagger url and swagger version using environment variables
- Add error handling for invalid swagger urls when downloading swagger json document
- Minor documentation update
- Fix reference to `generate.py` in make file.
