### PR TITLE
Return dict instead of list

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -149,7 +149,7 @@ class Operation:
         self.api_path = api_path
         self.produces = produces
 
-    def get_response_str(self, code=None):
+    def get_response_str(self, code=None, response_list=False):
 
         # case to handle v11 Ping Fed, operations can return different response objects
         # dependent on the HTTP response code
@@ -157,6 +157,9 @@ class Operation:
             for response_code in self.response_codes:
                 if response_code["code"] == code and "type" in response_code:
                     return f"Model{response_code['type']}.from_dict(response.json())"
+
+        if response_list:
+            return f"Model{self.type}.from_dict(response_dict)"
 
         if get_py_type(self.json_type) not in ("", "None") and self.is_primitive_type:
             return f"{self.type}(response)"

--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -52,7 +52,7 @@ class {{ safe_class_name(class_name) }}:
                 raise ValidationError(ModelApiResult.from_dict(response.json()).to_dict())
 {% elif response_code["code"] in (200, 201) %}
                 self.logger.info("{{ response_code["message"] }}")
-            if type(response.json()) is list:
+            if isinstance(response.json(), list):
                 response_dict = {'items': response.json()}
                 return {{ operation.get_response_str(response_code["code"], True) }}
             else:

--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -52,7 +52,11 @@ class {{ safe_class_name(class_name) }}:
                 raise ValidationError(ModelApiResult.from_dict(response.json()).to_dict())
 {% elif response_code["code"] in (200, 201) %}
                 self.logger.info("{{ response_code["message"] }}")
-            return {{ operation.get_response_str(response_code["code"]) }}
+            if type(response.json()) is list:
+                response_dict = {'items': response.json()}
+                return {{ operation.get_response_str(response_code["code"], True) }}
+            else:
+                return {{ operation.get_response_str(response_code["code"]) }}
 {% elif response_code["code"] == 204 %}
                 self.logger.info("{{ response_code["message"] }}")
                 return ModelApiResult(message="{{ response_code["message"] }}", validationErrors=[])


### PR DESCRIPTION
## Description

Return dict instead of list for models that expect a dict being returned for API operations.

**OauthAccessTokenMappings.getMappings()**
```
            if type(response.json()) is list:
                response_dict = {'items': response.json()}
                return ModelAccessTokenMappings.from_dict(response_dict)
            else:
                return ModelAccessTokenMappings.from_dict(response.json())
```

