### PR TITLE
Fix conflicts when enum with same name as model is imported in the model's class definition file

### DIFF
--- a/src/fetch.py
+++ b/src/fetch.py
@@ -197,6 +197,10 @@ class Fetch():
                     model_property = Property(prop, model_name, prop_name)
                     model_import = model_property.get_model_import()
                     enum_import = model_property.get_enum_import()
+                    if enum_import == model_name:
+                        import_suffix = f' as {enum_import}Enum'
+                    else:
+                        import_suffix = ''
                     if model_property.type == "DataStore" or \
                        model_property.type == "list" and \
                        model_property.sub_type == "DataStore":
@@ -204,10 +208,10 @@ class Fetch():
                         imports["models"].add("CustomDataStore")
                         imports["models"].add("LdapDataStore")
                         imports["models"].add("DataStore")
-                    if model_import and model_import not in imports["models"]:
+                    if model_import:
                         imports["models"].add(model_import)
-                    if enum_import and enum_import not in imports["enums"]:
-                        imports["enums"].add(enum_import)
+                    if enum_import:
+                        imports["enums"].add((enum_import, import_suffix))
 
                     enums = model_property.get_enums()
                     if enums:
@@ -218,6 +222,7 @@ class Fetch():
 
             details["properties"] = model_props
             details["imports"] = imports
+            details["conflict_suffix"] = Property.CONFLICT_SUFFIX
 
             self.models[model_name] = details
 

--- a/src/property.py
+++ b/src/property.py
@@ -12,6 +12,14 @@ class Property:
      - if it is an enum what domain does it have
     """
 
+    # Sometimes enums have the same name as a model and if the enum is imported
+    # by the model there would be a name conflict whereby the imported enum is
+    # overshadowed by the model class. In such cases we import the enum under a
+    # different name (in the scope of the model class) by appending the suffix
+    # given by $CONFLICT_SUFFIX to the enum name, thereby making it different
+    # from the model name.
+    CONFLICT_SUFFIX = 'Enum'
+
     def __init__(self, raw_property: dict, model_name=None, property_name=None):
         self.raw_property_dict = raw_property
         self.sub_type = None
@@ -277,7 +285,10 @@ class Property:
                 return f"valid_data[k] = {start_bracket}{self.sub_type}(**x) for x in v{end_bracket}"
 
         elif self.json_type == "enum":
-            return f"valid_data[k] = {self.type}[v]"
+            if self.type == self.model_name:
+                return f"valid_data[k] = {self.type}{self.CONFLICT_SUFFIX}[v]"
+            else:
+                return f"valid_data[k] = {self.type}[v]"
 
         elif not get_py_type(self.json_type):
             return f"valid_data[k] = {self.type}(**v)"

--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -1,11 +1,14 @@
-import os
+from json import dumps
 import logging
+import os
 import traceback
 
-from json import dumps
 from requests import Session
 from requests.exceptions import HTTPError
-{{ details.get_exception_imports() }}
+
+{% for imp in details.exception_imports %}
+from pingfedsdk.exceptions import {{ imp }}
+{% endfor %}
 {% for imp in details.imports %}
 from pingfedsdk.models.{{ safe_module_name(imp) }} import {{ imp }} as Model{{ imp }}
 {% endfor %}
@@ -23,7 +26,18 @@ class {{ safe_class_name(class_name) }}:
         return f"{self.endpoint}{path}"
 {% for operation in details.operations %}
 
-    def {{ operation.nickname }}(self{% for parameter in operation.parameters %}{% if parameter.required %}, {{ parameter.safe_name }}: {{ parameter.get_parameter_str() }}{% endif %}{% endfor %}{% for parameter in operation.parameters %}{% if not parameter.required %}, {{ parameter.safe_name }}: {{ parameter.get_parameter_str() }} = None{% endif %}{% endfor %}):
+{% set params = namespace(all=['self']) %}
+{% for parameter in operation.required_params %}
+{%   set pname = parameter.safe_name %}
+{%   set ptype = parameter.get_parameter_str() %}
+{%   set _ = params.all.append('%s: %s' | format(pname, ptype)) %}
+{% endfor %}
+{% for parameter in operation.optional_params %}
+{%   set pname = parameter.safe_name %}
+{%   set ptype = parameter.get_parameter_str() %}
+{%   set _ = params.all.append('%s: %s = None' | format(pname, ptype)) %}
+{% endfor %}
+    def {{ operation.nickname }}({{ params.all | join(', ')}}):
         """ {{ operation.summary }}
         """
 

--- a/src/templates/models.j2
+++ b/src/templates/models.j2
@@ -1,15 +1,44 @@
+{#
+ # Ensure an object name does not clash with the model class name. If it does,
+ # then the clash can only be with an Enum class (since model classes will
+ # necessarily have unique names in the swagger definition) and therefore we
+ # append the specified suffix to the clashing enum class within the scope of
+ # this module
+ #}
+{% macro local_name(obj_name) %}
+{%   if obj_name == class_name %}{{ obj_name }}{{ details['conflict_suffix'] }}{% else %}{{ obj_name }}{% endif %}
+{% endmacro -%}
+
 from pingfedsdk.model import Model
 from enum import Enum
 {% for folder, imports in details.get('imports').items() %}
-{% for imp in imports %}
-{% if folder == 'models' %}
+{%   for imp in imports %}
+{%     if folder == 'models' %}
 from pingfedsdk.{{ folder }}.{{ safe_module_name(imp) }} import {{ imp }}
-{% endif %}
-{% if folder == 'enums' %}
-from pingfedsdk.{{ folder }} import {{ imp }}
-{% endif %}
+{%     endif %}
+{%     if folder == 'enums' %}
+{%       set enum_name = imp[0] %}
+{%       set suffix = imp[1] %}
+from pingfedsdk.{{ folder }} import {{ enum_name }}{{ suffix }}
+{%     endif %}
+{%   endfor %}
 {% endfor %}
+
+
+{# Build parameter declaration lists for the __init__ method #}
+{% set required = details.get('required', []) %}
+{% set params = namespace(required=[], optional=[], all=['self']) %}
+{% for property, attributes in details.get('properties', {}).items() %}
+{%   set pname = safe_name(property) %}
+{%   set ptype = local_name(attributes.type) %}
+{%   if property in required %}
+{%     set _ = params.required.append('%s: %s' | format(pname, ptype)) %}
+{%   else %}
+{%     set _ = params.optional.append('%s: %s = None' | format(pname, ptype)) %}
+{%   endif %}
 {% endfor %}
+{% set _ = params.all.extend(params.required) %}
+{% set _ = params.all.extend(params.optional) -%}
 
 
 class {{ class_name }}(Model):
@@ -24,8 +53,7 @@ class {{ class_name }}(Model):
 {% endif %}
 {% endfor %}
     """
-
-    def __init__(self{% for property in details.get('required', []) %}, {{ safe_name(property) }}: {{ details['properties'][property].type }}{% endfor %}{% for property, attributes in details.get('properties', {}).items() if property not in details.get('required', []) %}, {{ property }}: {{ attributes.type }} = None{% endfor %}) -> None:
+    def __init__({{ params.all | join(', ') }}) -> None:
 {% if not details["properties"] %}        pass
 {% endif %}
 {% for property in details.get('properties') %}
@@ -33,7 +61,7 @@ class {{ class_name }}(Model):
 {% endfor %}
 
     def _validate(self) -> bool:
-        return any(x for x in [{% for property in details.get('required', []) %}"{{ property }}"{% if not loop.last %}, {% endif %}{% endfor %}] if self.__dict__[x] is not None)
+        return any(x for x in [{% for property in required %}"{{ property }}"{% if not loop.last %}, {% endif %}{% endfor %}] if self.__dict__[x] is not None)
 
     def __eq__(self, other) -> bool:
         if isinstance(other, {{ class_name }}):

--- a/src/templates/models.j2
+++ b/src/templates/models.j2
@@ -6,39 +6,42 @@
  # this module
  #}
 {% macro local_name(obj_name) %}
-{%   if obj_name == class_name %}{{ obj_name }}{{ details['conflict_suffix'] }}{% else %}{{ obj_name }}{% endif %}
+{%   if obj_name == class_name %}{{ obj_name }}{{ details.conflict_suffix }}{% else %}{{ obj_name }}{% endif %}
 {% endmacro -%}
 
-from pingfedsdk.model import Model
 from enum import Enum
+
 {% for folder, imports in details.get('imports').items() %}
-{%   for imp in imports %}
-{%     if folder == 'models' %}
-from pingfedsdk.{{ folder }}.{{ safe_module_name(imp) }} import {{ imp }}
-{%     endif %}
-{%     if folder == 'enums' %}
+{%   if folder == 'enums' %}
+{%     for imp in imports %}
 {%       set enum_name = imp[0] %}
 {%       set suffix = imp[1] %}
 from pingfedsdk.{{ folder }} import {{ enum_name }}{{ suffix }}
-{%     endif %}
-{%   endfor %}
+{%     endfor %}
+{%   elif folder == 'models' %}
+{%     for imp in imports %}
+from pingfedsdk.{{ folder }}.{{ safe_module_name(imp) }} import {{ imp }}
+{%     endfor %}
+{%   else %}
+{%     for imp in imports %}
+from pingfedsdk.{{ folder }} import {{ imp }}
+{%     endfor %}
+{%   endif %}
 {% endfor %}
 
 
 {# Build parameter declaration lists for the __init__ method #}
-{% set required = details.get('required', []) %}
-{% set params = namespace(required=[], optional=[], all=['self']) %}
-{% for property, attributes in details.get('properties', {}).items() %}
-{%   set pname = safe_name(property) %}
-{%   set ptype = local_name(attributes.type) %}
-{%   if property in required %}
-{%     set _ = params.required.append('%s: %s' | format(pname, ptype)) %}
-{%   else %}
-{%     set _ = params.optional.append('%s: %s = None' | format(pname, ptype)) %}
-{%   endif %}
+{% set params = namespace(all=['self']) %}
+{% for property in details.sorted_required %}
+{%   set pname = safe_name(property.name) %}
+{%   set ptype = local_name(property.type) %}
+{%   set _ = params.all.append('%s: %s' | format(pname, ptype)) %}
 {% endfor %}
-{% set _ = params.all.extend(params.required) %}
-{% set _ = params.all.extend(params.optional) -%}
+{% for property in details.sorted_optional %}
+{%   set pname = safe_name(property.name) %}
+{%   set ptype = local_name(property.type) %}
+{%   set _ = params.all.append('%s: %s = None' | format(pname, ptype)) %}
+{% endfor -%}
 
 
 class {{ class_name }}(Model):
@@ -61,7 +64,7 @@ class {{ class_name }}(Model):
 {% endfor %}
 
     def _validate(self) -> bool:
-        return any(x for x in [{% for property in required %}"{{ property }}"{% if not loop.last %}, {% endif %}{% endfor %}] if self.__dict__[x] is not None)
+        return any(x for x in [{{ details.get('required', []) | map('tojson') | join(', ') }}] if self.__dict__[x] is not None)
 
     def __eq__(self, other) -> bool:
         if isinstance(other, {{ class_name }}):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,7 +41,7 @@ class TestApiEndpoint(TestCase):
             "path": "/test/path/{id}"
         }])
 
-        self.assertEqual(api_endpoint.imports, {"Penguin"})
+        self.assertEqual(api_endpoint.imports, ["Penguin"])
         self.assertEqual(api_endpoint.response_codes, {200, 403, 422, 201})
 
 
@@ -122,7 +122,7 @@ class TestApiEndpointV11(TestCase):
                 ]
             }}, v11=True)
 
-        self.assertEqual(api_endpoint.imports, {"AdministrativeAccount", "ApiResult", "AdministrativeAccounts"})
+        self.assertEqual(api_endpoint.imports, sorted(["AdministrativeAccount", "ApiResult", "AdministrativeAccounts"]))
         self.assertEqual(api_endpoint.response_codes, {'422', '404', '200'})
 
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -28,11 +28,13 @@ class TestFetch(TestCase):
             data=self.session_mock.get.return_value.json.return_value,
             name="pf-admin-api", directory="../pingfedsdk/source/",
         )
-        self.logging_mock.info.assert_called_once_with(
-            "Successfully downloaded Ping Swagger document: "
-            "https://dummy.url/doc"
-        )
-
+        expected_log_calls = [
+            call("Successfully downloaded Ping Swagger document: "
+                 "https://dummy.url/doc"),
+            call("Writing source data to pingfedsdk/source/pf-admin-api.json"),
+        ]
+        self.assertEqual(self.logging_mock.info.call_args_list,
+                         expected_log_calls)
         self.session_mock.get.side_effect = Exception("test exception")
         self.assertRaises(ConnectionError, self.fetch.get_source)
         self.logging_mock.error.assert_called_once_with(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -114,8 +114,10 @@ class TestGenerate(TestCase):
                     },
                     "imports": {
                         "enums": [("PenguinLabeller", ' as PenguinLabellerEnum')],
+                        "model": ["Model"],
                     },
                     "conflict_suffix": Property.CONFLICT_SUFFIX,
+                    "sorted_required": [],
                 },
                 "Penguin": {
                     "api_references": ["penguins"],
@@ -139,8 +141,9 @@ class TestGenerate(TestCase):
                             "type": "string"
                         }, property_name="soundMade", model_name="Penguin")
                     },
-                    "imports": {},
+                    "imports": {"model": ["Model"]},
                     "conflict_suffix": Property.CONFLICT_SUFFIX,
+                    "sorted_required": [],
                 },
                 "Penguins": {
                     "api_references": ["penguins"],
@@ -155,11 +158,15 @@ class TestGenerate(TestCase):
                             "type": "array"
                         }, property_name="items")
                     },
-                    "imports": {},
+                    "imports": {"models": ["Model"]},
                     "conflict_suffix": Property.CONFLICT_SUFFIX,
+                    "sorted_required": [],
                 }
             }
         }
+        for model in self.fetch_response['models'].values():
+            model['sorted_optional'] = sorted(model['properties'].values(),
+                                              key=lambda p: p.name)
         for api, api_data in self.fetch_response['apis'].items():
             self.fetch_response['apis'][api] = ApiEndpoint(
                 '/test/endpoint', self.fetch_response['apis'][api]['details']


### PR DESCRIPTION
* Fix generator to generate an alternate name for the enum class when it is imported to a model class with the same name.

* Also ensure model constructor args are "stable" (i.e. don't change across different generator runs and versions) if the spec for the model does not change. This allows client calls to continue working across versions (provided the model has not changed).