### PR TITLE
Fix Modelvoid

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -52,6 +52,8 @@ class ApiEndpoint:
                     op_code["type"] = response_data["schema"]["$ref"].split("/")[-1]
                 elif "schema" in response_data and "type" in response_data["schema"]:
                     op_code["type"] = response_data["schema"]["type"]
+                elif "schema" not in response_data and response_code == "200":
+                    op_code["type"] = str(op_type)
                 else:
                     op_code["type"] = "void"
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -70,22 +70,23 @@ def get_py_type(json_type):
     Given a JSON type return a corresponding Python type.
     If no type can be determined, return an empty string.
     """
-
-    if json_type in ("enum", "string", "File", "file"):
-        return "str"
-    elif json_type == "boolean":
-        return "bool"
-    elif json_type == "array":
-        return "list"
-    elif json_type == "integer":
-        return "int"
-    elif json_type == "int":
-        return "int"
-    elif json_type == "number":
-        return "float"
-    elif json_type == "void":
-        return "None"
-    return ""
+    match json_type:
+        case 'enum' | 'string' | 'File' | 'file':
+            return 'str'
+        case 'boolean':
+            return 'bool'
+        case 'array':
+            return 'list'
+        case 'integer':
+            return 'int'
+        case 'int':
+            return 'int'
+        case 'number':
+            return 'float'
+        case 'void' | 'None':
+            return 'None'
+        case _:
+            return ''
 
 
 def get_auth_session():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -62,6 +62,10 @@ class TestHelpers(TestCase):
             "int"
         )
         self.assertEqual(
+            get_py_type("int"),
+            "int"
+        )
+        self.assertEqual(
             get_py_type("number"),
             "float"
         )


### PR DESCRIPTION
### Description

The SDK generates a `return Modelvoid.from_dict(response.json())` based on API endpoints that define a 200 response without a schema in the Swagger file. The intent of this pull request is to add a conditional statement that captures this edge case scenario in order to return a response in the API without a Model validation.