### PR TITLE
Fix response code handling in API templates

### DIFF
--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -64,14 +64,14 @@ class {{ safe_class_name(class_name) }}:
             if response.status_code == {{ response_code["code"] }}:
 {% if response_code["code"] == "422" %}
                 raise ValidationError(response.json())
-{% elif response_code["code"] in (200, 201) %}
+{% elif response_code["code"] in ("200", "201") %}
                 self.logger.info("{{ response_code["message"] }}")
             if isinstance(response.json(), list):
                 response_dict = {'items': response.json()}
                 return {{ operation.get_response_str(response_code["code"], True) }}
             else:
                 return {{ operation.get_response_str(response_code["code"]) }}
-{% elif response_code["code"] == 204 %}
+{% elif response_code["code"] == "204" %}
                 self.logger.info("{{ response_code["message"] }}")
                 return ModelApiResult(message="{{ response_code["message"] }}", validationErrors=[])
 {% elif details.get_exception_by_code(response_code["code"]) %}

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -38,7 +38,7 @@ class TestGenerate(TestCase):
             "apis": {
                 "/penguins": {
                     "imports": set(["Penguin"]),
-                    "codes": {200, 404},
+                    "codes": {"200", "404"},
                     "details": [{
                         "operations": [
                             {
@@ -48,7 +48,7 @@ class TestGenerate(TestCase):
                                 "parameters": [],
                                 "responseMessages": [
                                     {
-                                        "code": 200,
+                                        "code": "200",
                                         "message": "Success."
                                     }
                                 ],
@@ -72,11 +72,11 @@ class TestGenerate(TestCase):
                                 ],
                                 "responseMessages": [
                                     {
-                                        "code": 200,
+                                        "code": "200",
                                         "message": "Penguin uploaded."
                                     },
                                     {
-                                        "code": 404,
+                                        "code": "404",
                                         "message":
                                         "Validation error(s) occurred."
                                     }


### PR DESCRIPTION
The API templates currently have sections of code that treat response codes as integers though they are actually strings, resulting in incorrectly generated code.