### PR TITLE
Typecast response codes to string before comparing

### DIFF
--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -62,16 +62,16 @@ class {{ safe_class_name(class_name) }}:
         else:
 {% for response_code in operation.response_codes %}
             if response.status_code == {{ response_code["code"] }}:
-{% if response_code["code"] == "422" %}
+{% if response_code["code"] | string == "422" %}
                 raise ValidationError(response.json())
-{% elif response_code["code"] in ("200", "201") %}
+{% elif response_code["code"] | string in ("200", "201") %}
                 self.logger.info("{{ response_code["message"] }}")
             if isinstance(response.json(), list):
                 response_dict = {'items': response.json()}
                 return {{ operation.get_response_str(response_code["code"], True) }}
             else:
                 return {{ operation.get_response_str(response_code["code"]) }}
-{% elif response_code["code"] == "204" %}
+{% elif response_code["code"] | string == "204" %}
                 self.logger.info("{{ response_code["message"] }}")
                 return ModelApiResult(message="{{ response_code["message"] }}", validationErrors=[])
 {% elif details.get_exception_by_code(response_code["code"]) %}


### PR DESCRIPTION
The PingFederate swagger specification used to define response codes as integers when using Swagger 1.2 but defines them as strings in Swagger 2.0. Therefore, to preserve compatibility with older PingFederate versions, the code templates should typecast response codes to a common (known) type before making comparisons (to decide on what code needs to be emitted for what response types).

Note the actual response codes during execution of the generated code will always be integers - the response codes being processed by the generator are the response codes specified in the API Swagger definitions.