### PR TITLE
Fix handling of list response data

### DIFF
--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -66,11 +66,11 @@ class {{ safe_class_name(class_name) }}:
                 raise ValidationError(response.json())
 {% elif response_code["code"] | string in ("200", "201") %}
                 self.logger.info("{{ response_code["message"] }}")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return {{ operation.get_response_str(response_code["code"], True) }}
-            else:
-                return {{ operation.get_response_str(response_code["code"]) }}
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return {{ operation.get_response_str(response_code["code"], True) }}
+                else:
+                    return {{ operation.get_response_str(response_code["code"]) }}
 {% elif response_code["code"] | string == "204" %}
                 self.logger.info("{{ response_code["message"] }}")
                 return ModelApiResult(message="{{ response_code["message"] }}", validationErrors=[])


### PR DESCRIPTION
The code generated by the API template that transforms responses that return a JSON list into an object with an "item" attribute that contains the actual list needs to execute only in case of 200/201 responses and not against all response codes.