### PR TITLE
Generate SDK with fix for list handling of response data + Manual changes for config_archive file upload

### DIFF
--- a/pingfedsdk/apis/administrative_accounts.py
+++ b/pingfedsdk/apis/administrative_accounts.py
@@ -47,11 +47,11 @@ class AdministrativeAccounts:
         else:
             if response.status_code == 200:
                 self.logger.info("Administrator password changed.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelUserCredentials.from_dict(response_dict)
-            else:
-                return ModelUserCredentials.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelUserCredentials.from_dict(response_dict)
+                else:
+                    return ModelUserCredentials.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -76,11 +76,11 @@ class AdministrativeAccounts:
         else:
             if response.status_code == 200:
                 self.logger.info("Administrator password reset.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelUserCredentials.from_dict(response_dict)
-            else:
-                return ModelUserCredentials.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelUserCredentials.from_dict(response_dict)
+                else:
+                    return ModelUserCredentials.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -108,11 +108,11 @@ class AdministrativeAccounts:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdministrativeAccounts.from_dict(response_dict)
-            else:
-                return ModelAdministrativeAccounts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdministrativeAccounts.from_dict(response_dict)
+                else:
+                    return ModelAdministrativeAccounts.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -137,11 +137,11 @@ class AdministrativeAccounts:
         else:
             if response.status_code == 200:
                 self.logger.info("New Administrative Account created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdministrativeAccount.from_dict(response_dict)
-            else:
-                return ModelAdministrativeAccount.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdministrativeAccount.from_dict(response_dict)
+                else:
+                    return ModelAdministrativeAccount.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -169,11 +169,11 @@ class AdministrativeAccounts:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdministrativeAccount.from_dict(response_dict)
-            else:
-                return ModelAdministrativeAccount.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdministrativeAccount.from_dict(response_dict)
+                else:
+                    return ModelAdministrativeAccount.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -200,11 +200,11 @@ class AdministrativeAccounts:
         else:
             if response.status_code == 200:
                 self.logger.info("Administrator Account updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdministrativeAccount.from_dict(response_dict)
-            else:
-                return ModelAdministrativeAccount.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdministrativeAccount.from_dict(response_dict)
+                else:
+                    return ModelAdministrativeAccount.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/authentication_api.py
+++ b/pingfedsdk/apis/authentication_api.py
@@ -47,11 +47,11 @@ class AuthenticationApi:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthnApiApplication.from_dict(response_dict)
-            else:
-                return ModelAuthnApiApplication.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthnApiApplication.from_dict(response_dict)
+                else:
+                    return ModelAuthnApiApplication.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -78,11 +78,11 @@ class AuthenticationApi:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication API Application updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthnApiApplication.from_dict(response_dict)
-            else:
-                return ModelAuthnApiApplication.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthnApiApplication.from_dict(response_dict)
+                else:
+                    return ModelAuthnApiApplication.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -142,11 +142,11 @@ class AuthenticationApi:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthnApiSettings.from_dict(response_dict)
-            else:
-                return ModelAuthnApiSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthnApiSettings.from_dict(response_dict)
+                else:
+                    return ModelAuthnApiSettings.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -171,11 +171,11 @@ class AuthenticationApi:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthnApiSettings.from_dict(response_dict)
-            else:
-                return ModelAuthnApiSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthnApiSettings.from_dict(response_dict)
+                else:
+                    return ModelAuthnApiSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -203,11 +203,11 @@ class AuthenticationApi:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthnApiApplications.from_dict(response_dict)
-            else:
-                return ModelAuthnApiApplications.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthnApiApplications.from_dict(response_dict)
+                else:
+                    return ModelAuthnApiApplications.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -232,11 +232,11 @@ class AuthenticationApi:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication API Application created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthnApiApplication.from_dict(response_dict)
-            else:
-                return ModelAuthnApiApplication.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthnApiApplication.from_dict(response_dict)
+                else:
+                    return ModelAuthnApiApplication.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/authentication_policies.py
+++ b/pingfedsdk/apis/authentication_policies.py
@@ -50,11 +50,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPoliciesSettings.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPoliciesSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPoliciesSettings.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPoliciesSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelAuthenticationPoliciesSettings):
         """ Set the authentication policies settings.
@@ -77,11 +77,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPoliciesSettings.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPoliciesSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPoliciesSettings.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPoliciesSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -107,11 +107,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyTree.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyTree.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyTree.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyTree.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -138,11 +138,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyTree.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyTree.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyTree.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyTree.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -200,11 +200,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyFragment.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyFragment.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyFragment.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyFragment.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -231,11 +231,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication policy fragment updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyFragment.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyFragment.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyFragment.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyFragment.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -296,11 +296,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication policy created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyTree.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyTree.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyTree.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyTree.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -328,11 +328,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyFragments.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyFragments.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyFragments.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyFragments.from_dict(response.json())
 
     def createFragment(self, body: ModelAuthenticationPolicyFragment, XBypassExternalValidation: bool = None):
         """ Create an authentication policy fragment.
@@ -355,11 +355,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication policy fragment created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyFragment.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyFragment.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyFragment.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyFragment.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -387,11 +387,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicy.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicy.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicy.from_dict(response.json())
 
     def updateDefaultAuthenticationPolicy(self, body: ModelAuthenticationPolicy, XBypassExternalValidation: bool = None):
         """ Set the default authentication policy.
@@ -414,11 +414,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Default authentication policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicy.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicy.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -447,11 +447,11 @@ class AuthenticationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNone.from_dict(response_dict)
-            else:
-                return response.json()
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNone.from_dict(response_dict)
+                else:
+                    return response.json()
             if response.status_code == 422:
                 raise ValidationError(response.json())
             if response.status_code == 404:

--- a/pingfedsdk/apis/authentication_policy_contracts.py
+++ b/pingfedsdk/apis/authentication_policy_contracts.py
@@ -46,11 +46,11 @@ class AuthenticationPolicyContracts:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyContracts.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyContracts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyContracts.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyContracts.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -75,11 +75,11 @@ class AuthenticationPolicyContracts:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication policy contract created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyContract.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyContract.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyContract.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyContract.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -107,11 +107,11 @@ class AuthenticationPolicyContracts:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyContract.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyContract.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyContract.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyContract.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -138,11 +138,11 @@ class AuthenticationPolicyContracts:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication policy contract updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationPolicyContract.from_dict(response_dict)
-            else:
-                return ModelAuthenticationPolicyContract.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationPolicyContract.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationPolicyContract.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/authentication_selectors.py
+++ b/pingfedsdk/apis/authentication_selectors.py
@@ -48,11 +48,11 @@ class AuthenticationSelectors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSelector.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSelector.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSelector.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSelector.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -79,11 +79,11 @@ class AuthenticationSelectors:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication selector updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSelector.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSelector.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSelector.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSelector.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -143,11 +143,11 @@ class AuthenticationSelectors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSelectorDescriptors.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSelectorDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSelectorDescriptors.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSelectorDescriptors.from_dict(response.json())
 
     def getAuthenticationSelectorDescriptorsById(self, id: str):
         """ Get the description of an Authentication Selector plugin by ID.
@@ -169,11 +169,11 @@ class AuthenticationSelectors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSelectorDescriptor.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSelectorDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSelectorDescriptor.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSelectorDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -199,11 +199,11 @@ class AuthenticationSelectors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSelectors.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSelectors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSelectors.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSelectors.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -228,11 +228,11 @@ class AuthenticationSelectors:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication selector created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSelector.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSelector.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSelector.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSelector.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/bulk.py
+++ b/pingfedsdk/apis/bulk.py
@@ -44,11 +44,11 @@ class Bulk:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelBulkConfig.from_dict(response_dict)
-            else:
-                return ModelBulkConfig.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelBulkConfig.from_dict(response_dict)
+                else:
+                    return ModelBulkConfig.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) The current configuration cannot be bulk exported."
                 self.logger.info(message)
@@ -75,11 +75,11 @@ class Bulk:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNone.from_dict(response_dict)
-            else:
-                return response.json()
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNone.from_dict(response_dict)
+                else:
+                    return response.json()
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/certificates_ca.py
+++ b/pingfedsdk/apis/certificates_ca.py
@@ -47,11 +47,11 @@ class CertificatesCa:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertViews.from_dict(response_dict)
-            else:
-                return ModelCertViews.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertViews.from_dict(response_dict)
+                else:
+                    return ModelCertViews.from_dict(response.json())
 
     def getTrustedCert(self, id: str):
         """ Retrieve details of a trusted certificate authority.
@@ -73,11 +73,11 @@ class CertificatesCa:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertView.from_dict(response_dict)
-            else:
-                return ModelCertView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertView.from_dict(response_dict)
+                else:
+                    return ModelCertView.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -129,11 +129,11 @@ class CertificatesCa:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -160,11 +160,11 @@ class CertificatesCa:
         else:
             if response.status_code == 201:
                 self.logger.info("Certificate Authority imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertView.from_dict(response_dict)
-            else:
-                return ModelCertView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertView.from_dict(response_dict)
+                else:
+                    return ModelCertView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/certificates_groups.py
+++ b/pingfedsdk/apis/certificates_groups.py
@@ -47,11 +47,11 @@ class CertificatesGroups:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertViews.from_dict(response_dict)
-            else:
-                return ModelCertViews.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertViews.from_dict(response_dict)
+                else:
+                    return ModelCertViews.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -77,11 +77,11 @@ class CertificatesGroups:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertView.from_dict(response_dict)
-            else:
-                return ModelCertView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertView.from_dict(response_dict)
+                else:
+                    return ModelCertView.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -134,11 +134,11 @@ class CertificatesGroups:
         else:
             if response.status_code == 201:
                 self.logger.info("Group certificate imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertView.from_dict(response_dict)
-            else:
-                return ModelCertView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertView.from_dict(response_dict)
+                else:
+                    return ModelCertView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/certificates_revocation.py
+++ b/pingfedsdk/apis/certificates_revocation.py
@@ -48,11 +48,11 @@ class CertificatesRevocation:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertificateRevocationSettings.from_dict(response_dict)
-            else:
-                return ModelCertificateRevocationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertificateRevocationSettings.from_dict(response_dict)
+                else:
+                    return ModelCertificateRevocationSettings.from_dict(response.json())
 
     def updateRevocationSettings(self, body: ModelCertificateRevocationSettings):
         """ Update certificate revocation settings.
@@ -75,11 +75,11 @@ class CertificatesRevocation:
         else:
             if response.status_code == 200:
                 self.logger.info("Certificate revocation settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertificateRevocationSettings.from_dict(response_dict)
-            else:
-                return ModelCertificateRevocationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertificateRevocationSettings.from_dict(response_dict)
+                else:
+                    return ModelCertificateRevocationSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -107,11 +107,11 @@ class CertificatesRevocation:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertViews.from_dict(response_dict)
-            else:
-                return ModelCertViews.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertViews.from_dict(response_dict)
+                else:
+                    return ModelCertViews.from_dict(response.json())
 
     def importOcspCertificate(self, body: ModelX509File):
         """ Import an OCSP responder signature verification certificate.
@@ -134,11 +134,11 @@ class CertificatesRevocation:
         else:
             if response.status_code == 201:
                 self.logger.info("OCSP responder signature verification certificate imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertView.from_dict(response_dict)
-            else:
-                return ModelCertView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertView.from_dict(response_dict)
+                else:
+                    return ModelCertView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -166,11 +166,11 @@ class CertificatesRevocation:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCertView.from_dict(response_dict)
-            else:
-                return ModelCertView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCertView.from_dict(response_dict)
+                else:
+                    return ModelCertView.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/cluster.py
+++ b/pingfedsdk/apis/cluster.py
@@ -42,11 +42,11 @@ class Cluster:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClusterStatus.from_dict(response_dict)
-            else:
-                return ModelClusterStatus.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClusterStatus.from_dict(response_dict)
+                else:
+                    return ModelClusterStatus.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) This PingFederate instance is not deployed in clustered mode."
                 self.logger.info(message)
@@ -72,11 +72,11 @@ class Cluster:
         else:
             if response.status_code == 200:
                 self.logger.info("Replication completed successfully.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApiResult.from_dict(response.json())
-            else:
-                return ModelApiResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApiResult.from_dict(response.json())
+                else:
+                    return ModelApiResult.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) This PingFederate instance is not deployed in clustered mode."
                 self.logger.info(message)

--- a/pingfedsdk/apis/config_archive.py
+++ b/pingfedsdk/apis/config_archive.py
@@ -41,11 +41,11 @@ class ConfigArchive:
         else:
             if response.status_code == 200:
                 self.logger.info("Configuration Archive imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApiResult.from_dict(response.json())
-            else:
-                return ModelApiResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApiResult.from_dict(response.json())
+                else:
+                    return ModelApiResult.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -69,8 +69,8 @@ class ConfigArchive:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNone.from_dict(response_dict)
-            else:
-                return response
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNone.from_dict(response_dict)
+                else:
+                    return response

--- a/pingfedsdk/apis/config_store.py
+++ b/pingfedsdk/apis/config_store.py
@@ -47,11 +47,11 @@ class ConfigStore:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConfigStoreBundle.from_dict(response_dict)
-            else:
-                return ModelConfigStoreBundle.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConfigStoreBundle.from_dict(response_dict)
+                else:
+                    return ModelConfigStoreBundle.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) The specified configuration bundle is unavailable."
                 self.logger.info(message)
@@ -81,11 +81,11 @@ class ConfigStore:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConfigStoreSetting.from_dict(response_dict)
-            else:
-                return ModelConfigStoreSetting.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConfigStoreSetting.from_dict(response_dict)
+                else:
+                    return ModelConfigStoreSetting.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) The specified configuration bundle is unavailable."
                 self.logger.info(message)
@@ -116,11 +116,11 @@ class ConfigStore:
         else:
             if response.status_code == 200:
                 self.logger.info("Configuration setting created/updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConfigStoreSetting.from_dict(response_dict)
-            else:
-                return ModelConfigStoreSetting.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConfigStoreSetting.from_dict(response_dict)
+                else:
+                    return ModelConfigStoreSetting.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/configuration_encryption_keys.py
+++ b/pingfedsdk/apis/configuration_encryption_keys.py
@@ -40,11 +40,11 @@ class ConfigurationEncryptionKeys:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConfigurationEncryptionKeys.from_dict(response_dict)
-            else:
-                return ModelConfigurationEncryptionKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConfigurationEncryptionKeys.from_dict(response_dict)
+                else:
+                    return ModelConfigurationEncryptionKeys.from_dict(response.json())
 
     def rotateConfigurationEncryptionKey(self):
         """ Rotate the current Configuration Encryption Key.
@@ -66,8 +66,8 @@ class ConfigurationEncryptionKeys:
         else:
             if response.status_code == 201:
                 self.logger.info("Configuration encryption key rotated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConfigurationEncryptionKeys.from_dict(response_dict)
-            else:
-                return ModelConfigurationEncryptionKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConfigurationEncryptionKeys.from_dict(response_dict)
+                else:
+                    return ModelConfigurationEncryptionKeys.from_dict(response.json())

--- a/pingfedsdk/apis/connection_metadata.py
+++ b/pingfedsdk/apis/connection_metadata.py
@@ -46,11 +46,11 @@ class ConnectionMetadata:
         else:
             if response.status_code == 200:
                 self.logger.info("Partner's SAML metadata converted.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConvertMetadataResponse.from_dict(response_dict)
-            else:
-                return ModelConvertMetadataResponse.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConvertMetadataResponse.from_dict(response_dict)
+                else:
+                    return ModelConvertMetadataResponse.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -79,11 +79,11 @@ class ConnectionMetadata:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection SAML metadata exported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/data_stores.py
+++ b/pingfedsdk/apis/data_stores.py
@@ -52,11 +52,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAction.from_dict(response_dict)
-            else:
-                return ModelAction.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAction.from_dict(response_dict)
+                else:
+                    return ModelAction.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -83,11 +83,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Action invoked on Data store.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActionResult.from_dict(response_dict)
-            else:
-                return ModelActionResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActionResult.from_dict(response_dict)
+                else:
+                    return ModelActionResult.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -113,11 +113,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCustomDataStoreDescriptors.from_dict(response_dict)
-            else:
-                return ModelCustomDataStoreDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCustomDataStoreDescriptors.from_dict(response_dict)
+                else:
+                    return ModelCustomDataStoreDescriptors.from_dict(response.json())
 
     def getCustomDataStoreDescriptor(self, id: str):
         """ Get the description of a custom data store plugin by ID.
@@ -139,11 +139,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCustomDataStoreDescriptor.from_dict(response_dict)
-            else:
-                return ModelCustomDataStoreDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCustomDataStoreDescriptor.from_dict(response_dict)
+                else:
+                    return ModelCustomDataStoreDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -169,11 +169,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDataStores.from_dict(response_dict)
-            else:
-                return ModelDataStores.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDataStores.from_dict(response_dict)
+                else:
+                    return ModelDataStores.from_dict(response.json())
 
     def createDataStore(self, body: ModelDataStore, XBypassExternalValidation: bool = None):
         """ Create a new data store.
@@ -196,11 +196,11 @@ class DataStores:
         else:
             if response.status_code == 201:
                 self.logger.info("Data store created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDataStore.from_dict(response_dict)
-            else:
-                return ModelDataStore.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDataStore.from_dict(response_dict)
+                else:
+                    return ModelDataStore.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -228,11 +228,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDataStore.from_dict(response_dict)
-            else:
-                return ModelDataStore.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDataStore.from_dict(response_dict)
+                else:
+                    return ModelDataStore.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -259,11 +259,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Data store updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDataStore.from_dict(response_dict)
-            else:
-                return ModelDataStore.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDataStore.from_dict(response_dict)
+                else:
+                    return ModelDataStore.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -323,11 +323,11 @@ class DataStores:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActions.from_dict(response_dict)
-            else:
-                return ModelActions.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActions.from_dict(response_dict)
+                else:
+                    return ModelActions.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/extended_properties.py
+++ b/pingfedsdk/apis/extended_properties.py
@@ -42,11 +42,11 @@ class ExtendedProperties:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelExtendedProperties.from_dict(response_dict)
-            else:
-                return ModelExtendedProperties.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelExtendedProperties.from_dict(response_dict)
+                else:
+                    return ModelExtendedProperties.from_dict(response.json())
 
     def updateExtendedProperties(self, body: ModelExtendedProperties):
         """ Update the Extended Properties.
@@ -69,10 +69,10 @@ class ExtendedProperties:
         else:
             if response.status_code == 200:
                 self.logger.info("Extended properties updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelExtendedProperties.from_dict(response_dict)
-            else:
-                return ModelExtendedProperties.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelExtendedProperties.from_dict(response_dict)
+                else:
+                    return ModelExtendedProperties.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())

--- a/pingfedsdk/apis/identity_store_provisioners.py
+++ b/pingfedsdk/apis/identity_store_provisioners.py
@@ -48,11 +48,11 @@ class IdentityStoreProvisioners:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdentityStoreProvisioner.from_dict(response_dict)
-            else:
-                return ModelIdentityStoreProvisioner.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdentityStoreProvisioner.from_dict(response_dict)
+                else:
+                    return ModelIdentityStoreProvisioner.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -79,11 +79,11 @@ class IdentityStoreProvisioners:
         else:
             if response.status_code == 200:
                 self.logger.info("Identity store provisioner updated")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdentityStoreProvisioner.from_dict(response_dict)
-            else:
-                return ModelIdentityStoreProvisioner.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdentityStoreProvisioner.from_dict(response_dict)
+                else:
+                    return ModelIdentityStoreProvisioner.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -143,11 +143,11 @@ class IdentityStoreProvisioners:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdentityStoreProvisioners.from_dict(response_dict)
-            else:
-                return ModelIdentityStoreProvisioners.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdentityStoreProvisioners.from_dict(response_dict)
+                else:
+                    return ModelIdentityStoreProvisioners.from_dict(response.json())
 
     def createIdentityStoreProvisioner(self, body: ModelIdentityStoreProvisioner):
         """ Create a new identity store provisioner instance.
@@ -170,18 +170,18 @@ class IdentityStoreProvisioners:
         else:
             if response.status_code == 200:
                 self.logger.info("successful operation")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdentityStoreProvisioner.from_dict(response_dict)
-            else:
-                return ModelIdentityStoreProvisioner.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdentityStoreProvisioner.from_dict(response_dict)
+                else:
+                    return ModelIdentityStoreProvisioner.from_dict(response.json())
             if response.status_code == 201:
                 self.logger.info("Identity store provisioner created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdentityStoreProvisioner.from_dict(response_dict)
-            else:
-                return ModelIdentityStoreProvisioner.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdentityStoreProvisioner.from_dict(response_dict)
+                else:
+                    return ModelIdentityStoreProvisioner.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -209,11 +209,11 @@ class IdentityStoreProvisioners:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdentityStoreProvisionerDescriptors.from_dict(response_dict)
-            else:
-                return ModelIdentityStoreProvisionerDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdentityStoreProvisionerDescriptors.from_dict(response_dict)
+                else:
+                    return ModelIdentityStoreProvisionerDescriptors.from_dict(response.json())
 
     def getIdentityStoreProvisionerDescriptorById(self, id: str):
         """ Get the descriptor of an identity store provisioner by ID.
@@ -235,11 +235,11 @@ class IdentityStoreProvisioners:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdentityStoreProvisionerDescriptor.from_dict(response_dict)
-            else:
-                return ModelIdentityStoreProvisionerDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdentityStoreProvisionerDescriptor.from_dict(response_dict)
+                else:
+                    return ModelIdentityStoreProvisionerDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/idp_adapters.py
+++ b/pingfedsdk/apis/idp_adapters.py
@@ -52,11 +52,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAction.from_dict(response_dict)
-            else:
-                return ModelAction.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAction.from_dict(response_dict)
+                else:
+                    return ModelAction.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -83,11 +83,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Action invoked on adapter.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActionResult.from_dict(response_dict)
-            else:
-                return ModelActionResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActionResult.from_dict(response_dict)
+                else:
+                    return ModelActionResult.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -113,11 +113,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapterDescriptors.from_dict(response_dict)
-            else:
-                return ModelIdpAdapterDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapterDescriptors.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapterDescriptors.from_dict(response.json())
 
     def getIdpAdapterDescriptorsById(self, id: str):
         """ Get the description of an IdP adapter plugin by ID.
@@ -139,11 +139,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapterDescriptor.from_dict(response_dict)
-            else:
-                return ModelIdpAdapterDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapterDescriptor.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapterDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -169,11 +169,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapters.from_dict(response_dict)
-            else:
-                return ModelIdpAdapters.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapters.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapters.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -198,11 +198,11 @@ class IdpAdapters:
         else:
             if response.status_code == 201:
                 self.logger.info("Adapter created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapter.from_dict(response_dict)
-            else:
-                return ModelIdpAdapter.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapter.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapter.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -230,11 +230,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapter.from_dict(response_dict)
-            else:
-                return ModelIdpAdapter.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapter.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapter.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -261,11 +261,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Adapter updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapter.from_dict(response_dict)
-            else:
-                return ModelIdpAdapter.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapter.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapter.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -325,11 +325,11 @@ class IdpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActions.from_dict(response_dict)
-            else:
-                return ModelActions.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActions.from_dict(response_dict)
+                else:
+                    return ModelActions.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/idp_connectors.py
+++ b/pingfedsdk/apis/idp_connectors.py
@@ -41,11 +41,11 @@ class IdpConnectors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSaasPluginDescriptors.from_dict(response_dict)
-            else:
-                return ModelSaasPluginDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSaasPluginDescriptors.from_dict(response_dict)
+                else:
+                    return ModelSaasPluginDescriptors.from_dict(response.json())
 
     def getIdpConnectorDescriptorById(self, id: str):
         """ Get the list of available connector descriptors.
@@ -67,8 +67,8 @@ class IdpConnectors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSaasPluginDescriptor.from_dict(response_dict)
-            else:
-                return ModelSaasPluginDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSaasPluginDescriptor.from_dict(response_dict)
+                else:
+                    return ModelSaasPluginDescriptor.from_dict(response.json())

--- a/pingfedsdk/apis/idp_default_urls.py
+++ b/pingfedsdk/apis/idp_default_urls.py
@@ -43,11 +43,11 @@ class IdpDefaultUrls:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpDefaultUrl.from_dict(response_dict)
-            else:
-                return ModelIdpDefaultUrl.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpDefaultUrl.from_dict(response_dict)
+                else:
+                    return ModelIdpDefaultUrl.from_dict(response.json())
 
     def updateDefaultUrlSettings(self, body: ModelIdpDefaultUrl):
         """ Update the IDP Default URL settings.
@@ -70,11 +70,11 @@ class IdpDefaultUrls:
         else:
             if response.status_code == 200:
                 self.logger.info("Default URL updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpDefaultUrl.from_dict(response_dict)
-            else:
-                return ModelIdpDefaultUrl.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpDefaultUrl.from_dict(response_dict)
+                else:
+                    return ModelIdpDefaultUrl.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/idp_sp_connections.py
+++ b/pingfedsdk/apis/idp_sp_connections.py
@@ -50,11 +50,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpConnection.from_dict(response_dict)
-            else:
-                return ModelSpConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpConnection.from_dict(response_dict)
+                else:
+                    return ModelSpConnection.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -81,11 +81,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpConnection.from_dict(response_dict)
-            else:
-                return ModelSpConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpConnection.from_dict(response_dict)
+                else:
+                    return ModelSpConnection.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -145,11 +145,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpConnections.from_dict(response_dict)
-            else:
-                return ModelSpConnections.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpConnections.from_dict(response_dict)
+                else:
+                    return ModelSpConnections.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -174,11 +174,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 201:
                 self.logger.info("Connection created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpConnection.from_dict(response_dict)
-            else:
-                return ModelSpConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpConnection.from_dict(response_dict)
+                else:
+                    return ModelSpConnection.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -206,11 +206,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSigningSettings.from_dict(response_dict)
-            else:
-                return ModelSigningSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSigningSettings.from_dict(response_dict)
+                else:
+                    return ModelSigningSettings.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -237,11 +237,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSigningSettings.from_dict(response_dict)
-            else:
-                return ModelSigningSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSigningSettings.from_dict(response_dict)
+                else:
+                    return ModelSigningSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -273,11 +273,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConnectionCerts.from_dict(response_dict)
-            else:
-                return ModelConnectionCerts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConnectionCerts.from_dict(response_dict)
+                else:
+                    return ModelConnectionCerts.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -304,11 +304,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 201:
                 self.logger.info("Connection Certificate added.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConnectionCert.from_dict(response_dict)
-            else:
-                return ModelConnectionCert.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConnectionCert.from_dict(response_dict)
+                else:
+                    return ModelConnectionCert.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -341,11 +341,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConnectionCerts.from_dict(response_dict)
-            else:
-                return ModelConnectionCerts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConnectionCerts.from_dict(response_dict)
+                else:
+                    return ModelConnectionCerts.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -377,11 +377,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDecryptionKeys.from_dict(response_dict)
-            else:
-                return ModelDecryptionKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDecryptionKeys.from_dict(response_dict)
+                else:
+                    return ModelDecryptionKeys.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -408,11 +408,11 @@ class IdpSpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDecryptionKeys.from_dict(response_dict)
-            else:
-                return ModelDecryptionKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDecryptionKeys.from_dict(response_dict)
+                else:
+                    return ModelDecryptionKeys.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/idp_sts_request_parameters_contracts.py
+++ b/pingfedsdk/apis/idp_sts_request_parameters_contracts.py
@@ -46,11 +46,11 @@ class IdpStsRequestParametersContracts:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelStsRequestParametersContracts.from_dict(response_dict)
-            else:
-                return ModelStsRequestParametersContracts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelStsRequestParametersContracts.from_dict(response_dict)
+                else:
+                    return ModelStsRequestParametersContracts.from_dict(response.json())
 
     def createStsRequestParamContract(self, body: ModelStsRequestParametersContract):
         """ Create a new STS Request Parameters Contract.
@@ -73,11 +73,11 @@ class IdpStsRequestParametersContracts:
         else:
             if response.status_code == 201:
                 self.logger.info("STS Request Parameters Contract created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelStsRequestParametersContract.from_dict(response_dict)
-            else:
-                return ModelStsRequestParametersContract.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelStsRequestParametersContract.from_dict(response_dict)
+                else:
+                    return ModelStsRequestParametersContract.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class IdpStsRequestParametersContracts:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelStsRequestParametersContract.from_dict(response_dict)
-            else:
-                return ModelStsRequestParametersContract.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelStsRequestParametersContract.from_dict(response_dict)
+                else:
+                    return ModelStsRequestParametersContract.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class IdpStsRequestParametersContracts:
         else:
             if response.status_code == 200:
                 self.logger.info("STS Request Parameters Contract updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelStsRequestParametersContract.from_dict(response_dict)
-            else:
-                return ModelStsRequestParametersContract.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelStsRequestParametersContract.from_dict(response_dict)
+                else:
+                    return ModelStsRequestParametersContract.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/idp_to_sp_adapter_mapping.py
+++ b/pingfedsdk/apis/idp_to_sp_adapter_mapping.py
@@ -46,11 +46,11 @@ class IdpToSpAdapterMapping:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpToSpAdapterMappings.from_dict(response_dict)
-            else:
-                return ModelIdpToSpAdapterMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpToSpAdapterMappings.from_dict(response_dict)
+                else:
+                    return ModelIdpToSpAdapterMappings.from_dict(response.json())
 
     def createIdpToSpAdapterMapping(self, body: ModelIdpToSpAdapterMapping, XBypassExternalValidation: bool = None):
         """ Create a new IdP-to-SP Adapter mapping.
@@ -73,11 +73,11 @@ class IdpToSpAdapterMapping:
         else:
             if response.status_code == 201:
                 self.logger.info("IdP-to-SP adapter mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpToSpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelIdpToSpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpToSpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelIdpToSpAdapterMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class IdpToSpAdapterMapping:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpToSpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelIdpToSpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpToSpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelIdpToSpAdapterMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class IdpToSpAdapterMapping:
         else:
             if response.status_code == 200:
                 self.logger.info("IdP-to-SP adapter mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpToSpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelIdpToSpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpToSpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelIdpToSpAdapterMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/idp_token_processors.py
+++ b/pingfedsdk/apis/idp_token_processors.py
@@ -48,11 +48,11 @@ class IdpTokenProcessors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenProcessor.from_dict(response_dict)
-            else:
-                return ModelTokenProcessor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenProcessor.from_dict(response_dict)
+                else:
+                    return ModelTokenProcessor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -79,11 +79,11 @@ class IdpTokenProcessors:
         else:
             if response.status_code == 200:
                 self.logger.info("Token Processor updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenProcessor.from_dict(response_dict)
-            else:
-                return ModelTokenProcessor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenProcessor.from_dict(response_dict)
+                else:
+                    return ModelTokenProcessor.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -143,11 +143,11 @@ class IdpTokenProcessors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenProcessorDescriptors.from_dict(response_dict)
-            else:
-                return ModelTokenProcessorDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenProcessorDescriptors.from_dict(response_dict)
+                else:
+                    return ModelTokenProcessorDescriptors.from_dict(response.json())
 
     def getTokenProcessorDescriptorsById(self, id: str):
         """ Get the description of a token processor plugin by ID.
@@ -169,11 +169,11 @@ class IdpTokenProcessors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenProcessorDescriptor.from_dict(response_dict)
-            else:
-                return ModelTokenProcessorDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenProcessorDescriptor.from_dict(response_dict)
+                else:
+                    return ModelTokenProcessorDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -199,11 +199,11 @@ class IdpTokenProcessors:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenProcessors.from_dict(response_dict)
-            else:
-                return ModelTokenProcessors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenProcessors.from_dict(response_dict)
+                else:
+                    return ModelTokenProcessors.from_dict(response.json())
 
     def createTokenProcessor(self, body: ModelTokenProcessor):
         """ Create a new token processor instance.
@@ -226,11 +226,11 @@ class IdpTokenProcessors:
         else:
             if response.status_code == 201:
                 self.logger.info("Token processor created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenProcessor.from_dict(response_dict)
-            else:
-                return ModelTokenProcessor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenProcessor.from_dict(response_dict)
+                else:
+                    return ModelTokenProcessor.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/incoming_proxy_settings.py
+++ b/pingfedsdk/apis/incoming_proxy_settings.py
@@ -43,11 +43,11 @@ class IncomingProxySettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIncomingProxySettings.from_dict(response_dict)
-            else:
-                return ModelIncomingProxySettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIncomingProxySettings.from_dict(response_dict)
+                else:
+                    return ModelIncomingProxySettings.from_dict(response.json())
 
     def updateIncomingProxySettings(self, body: ModelIncomingProxySettings):
         """ Update incoming proxy settings.
@@ -70,11 +70,11 @@ class IncomingProxySettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Incoming proxy settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIncomingProxySettings.from_dict(response_dict)
-            else:
-                return ModelIncomingProxySettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIncomingProxySettings.from_dict(response_dict)
+                else:
+                    return ModelIncomingProxySettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/kerberos_realms.py
+++ b/pingfedsdk/apis/kerberos_realms.py
@@ -47,11 +47,11 @@ class KerberosRealms:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKerberosRealms.from_dict(response_dict)
-            else:
-                return ModelKerberosRealms.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKerberosRealms.from_dict(response_dict)
+                else:
+                    return ModelKerberosRealms.from_dict(response.json())
 
     def createKerberosRealm(self, body: ModelKerberosRealm, XBypassExternalValidation: bool = None):
         """ Create a new Kerberos Realm.
@@ -74,11 +74,11 @@ class KerberosRealms:
         else:
             if response.status_code == 201:
                 self.logger.info("Kerberos realm created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKerberosRealm.from_dict(response_dict)
-            else:
-                return ModelKerberosRealm.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKerberosRealm.from_dict(response_dict)
+                else:
+                    return ModelKerberosRealm.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -106,11 +106,11 @@ class KerberosRealms:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKerberosRealm.from_dict(response_dict)
-            else:
-                return ModelKerberosRealm.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKerberosRealm.from_dict(response_dict)
+                else:
+                    return ModelKerberosRealm.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -137,11 +137,11 @@ class KerberosRealms:
         else:
             if response.status_code == 200:
                 self.logger.info("Kerberos realm updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKerberosRealm.from_dict(response_dict)
-            else:
-                return ModelKerberosRealm.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKerberosRealm.from_dict(response_dict)
+                else:
+                    return ModelKerberosRealm.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -201,11 +201,11 @@ class KerberosRealms:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKerberosRealmsSettings.from_dict(response_dict)
-            else:
-                return ModelKerberosRealmsSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKerberosRealmsSettings.from_dict(response_dict)
+                else:
+                    return ModelKerberosRealmsSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelKerberosRealmsSettings):
         """ Set/Update the Kerberos Realms Settings.
@@ -228,11 +228,11 @@ class KerberosRealms:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKerberosRealmsSettings.from_dict(response_dict)
-            else:
-                return ModelKerberosRealmsSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKerberosRealmsSettings.from_dict(response_dict)
+                else:
+                    return ModelKerberosRealmsSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/key_pairs.py
+++ b/pingfedsdk/apis/key_pairs.py
@@ -40,8 +40,8 @@ class KeyPairs:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyAlgorithms.from_dict(response_dict)
-            else:
-                return ModelKeyAlgorithms.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyAlgorithms.from_dict(response_dict)
+                else:
+                    return ModelKeyAlgorithms.from_dict(response.json())

--- a/pingfedsdk/apis/key_pairs_oauth_open_id_connect.py
+++ b/pingfedsdk/apis/key_pairs_oauth_open_id_connect.py
@@ -47,11 +47,11 @@ class KeyPairsOauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdditionalKeySets.from_dict(response_dict)
-            else:
-                return ModelAdditionalKeySets.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdditionalKeySets.from_dict(response_dict)
+                else:
+                    return ModelAdditionalKeySets.from_dict(response.json())
 
     def createKeySet(self, body: ModelAdditionalKeySet):
         """ Create a new OAuth/OpenID Connect additional signing key set.
@@ -74,11 +74,11 @@ class KeyPairsOauthOpenIdConnect:
         else:
             if response.status_code == 201:
                 self.logger.info("OAuth/OpenID Connect key set created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdditionalKeySet.from_dict(response_dict)
-            else:
-                return ModelAdditionalKeySet.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdditionalKeySet.from_dict(response_dict)
+                else:
+                    return ModelAdditionalKeySet.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -106,11 +106,11 @@ class KeyPairsOauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdditionalKeySet.from_dict(response_dict)
-            else:
-                return ModelAdditionalKeySet.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdditionalKeySet.from_dict(response_dict)
+                else:
+                    return ModelAdditionalKeySet.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -137,11 +137,11 @@ class KeyPairsOauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("OAuth/OpenID Connect key set updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAdditionalKeySet.from_dict(response_dict)
-            else:
-                return ModelAdditionalKeySet.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAdditionalKeySet.from_dict(response_dict)
+                else:
+                    return ModelAdditionalKeySet.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -199,11 +199,11 @@ class KeyPairsOauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOAuthOidcKeysSettings.from_dict(response_dict)
-            else:
-                return ModelOAuthOidcKeysSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOAuthOidcKeysSettings.from_dict(response_dict)
+                else:
+                    return ModelOAuthOidcKeysSettings.from_dict(response.json())
 
     def updateOAuthOidcKeysSettings(self, body: ModelOAuthOidcKeysSettings):
         """ Update OAuth/OpenID Connect key settings.
@@ -226,11 +226,11 @@ class KeyPairsOauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("OAuth/Open ID Connect key settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOAuthOidcKeysSettings.from_dict(response_dict)
-            else:
-                return ModelOAuthOidcKeysSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOAuthOidcKeysSettings.from_dict(response_dict)
+                else:
+                    return ModelOAuthOidcKeysSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/key_pairs_signing.py
+++ b/pingfedsdk/apis/key_pairs_signing.py
@@ -52,11 +52,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairRotationSettings.from_dict(response_dict)
-            else:
-                return ModelKeyPairRotationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairRotationSettings.from_dict(response_dict)
+                else:
+                    return ModelKeyPairRotationSettings.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -83,11 +83,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Key Pair updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairRotationSettings.from_dict(response_dict)
-            else:
-                return ModelKeyPairRotationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairRotationSettings.from_dict(response_dict)
+                else:
+                    return ModelKeyPairRotationSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -146,11 +146,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 201:
                 self.logger.info("Key Pair imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -182,11 +182,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -240,11 +240,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairViews.from_dict(response_dict)
-            else:
-                return ModelKeyPairViews.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairViews.from_dict(response_dict)
+                else:
+                    return ModelKeyPairViews.from_dict(response.json())
 
     def createKeyPair(self, body: ModelNewKeyPairSettings):
         """ Generate a new key pair.
@@ -267,11 +267,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 201:
                 self.logger.info("Key Pair created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -299,11 +299,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
 
     def importCsrResponse(self, body: ModelCSRResponse, id: str):
         """ Import a CSR response for this key pair.
@@ -326,11 +326,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("CSR Response imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -363,11 +363,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Key Pair downloaded.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -404,11 +404,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Key Pair downloaded.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -444,11 +444,11 @@ class KeyPairsSigning:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/key_pairs_ssl_client.py
+++ b/pingfedsdk/apis/key_pairs_ssl_client.py
@@ -52,11 +52,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 201:
                 self.logger.info("Key Pair imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -88,11 +88,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -146,11 +146,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairViews.from_dict(response_dict)
-            else:
-                return ModelKeyPairViews.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairViews.from_dict(response_dict)
+                else:
+                    return ModelKeyPairViews.from_dict(response.json())
 
     def createKeyPair(self, body: ModelNewKeyPairSettings):
         """ Generate a new key pair.
@@ -173,11 +173,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 201:
                 self.logger.info("Key Pair created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -205,11 +205,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
 
     def importCsrResponse(self, body: ModelCSRResponse, id: str):
         """ Import a CSR response for this key pair.
@@ -232,11 +232,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 200:
                 self.logger.info("CSR Response imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -269,11 +269,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 200:
                 self.logger.info("Key Pair downloaded.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -310,11 +310,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 200:
                 self.logger.info("Key Pair downloaded.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -350,11 +350,11 @@ class KeyPairsSslClient:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/key_pairs_ssl_server.py
+++ b/pingfedsdk/apis/key_pairs_ssl_server.py
@@ -52,11 +52,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSslServerSettings.from_dict(response_dict)
-            else:
-                return ModelSslServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSslServerSettings.from_dict(response_dict)
+                else:
+                    return ModelSslServerSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelSslServerSettings):
         """ Update the SSL Server Certificate Settings.
@@ -79,11 +79,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("SSL Certificate Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSslServerSettings.from_dict(response_dict)
-            else:
-                return ModelSslServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSslServerSettings.from_dict(response_dict)
+                else:
+                    return ModelSslServerSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -112,11 +112,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 201:
                 self.logger.info("Key Pair imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -148,11 +148,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -206,11 +206,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairViews.from_dict(response_dict)
-            else:
-                return ModelKeyPairViews.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairViews.from_dict(response_dict)
+                else:
+                    return ModelKeyPairViews.from_dict(response.json())
 
     def createKeyPair(self, body: ModelNewKeyPairSettings):
         """ Generate a new key pair.
@@ -233,11 +233,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 201:
                 self.logger.info("Key Pair created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -265,11 +265,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
 
     def importCsrResponse(self, body: ModelCSRResponse, id: str):
         """ Import a CSR response for this key pair.
@@ -292,11 +292,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("CSR Response imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelKeyPairView.from_dict(response_dict)
-            else:
-                return ModelKeyPairView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelKeyPairView.from_dict(response_dict)
+                else:
+                    return ModelKeyPairView.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -329,11 +329,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("Key Pair downloaded.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -370,11 +370,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("Key Pair downloaded.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -410,11 +410,11 @@ class KeyPairsSslServer:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return Modelstr.from_dict(response_dict)
-            else:
-                return str(response)
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return Modelstr.from_dict(response_dict)
+                else:
+                    return str(response)
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/license.py
+++ b/pingfedsdk/apis/license.py
@@ -45,11 +45,11 @@ class License:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLicenseView.from_dict(response_dict)
-            else:
-                return ModelLicenseView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLicenseView.from_dict(response_dict)
+                else:
+                    return ModelLicenseView.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
             if response.status_code == 404:
@@ -78,11 +78,11 @@ class License:
         else:
             if response.status_code == 200:
                 self.logger.info("License imported.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLicenseView.from_dict(response_dict)
-            else:
-                return ModelLicenseView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLicenseView.from_dict(response_dict)
+                else:
+                    return ModelLicenseView.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -106,11 +106,11 @@ class License:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLicenseAgreementInfo.from_dict(response_dict)
-            else:
-                return ModelLicenseAgreementInfo.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLicenseAgreementInfo.from_dict(response_dict)
+                else:
+                    return ModelLicenseAgreementInfo.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -135,10 +135,10 @@ class License:
         else:
             if response.status_code == 200:
                 self.logger.info("License agreement accepted.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLicenseAgreementInfo.from_dict(response_dict)
-            else:
-                return ModelLicenseAgreementInfo.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLicenseAgreementInfo.from_dict(response_dict)
+                else:
+                    return ModelLicenseAgreementInfo.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())

--- a/pingfedsdk/apis/local_identity_identity_profiles.py
+++ b/pingfedsdk/apis/local_identity_identity_profiles.py
@@ -46,11 +46,11 @@ class LocalIdentityIdentityProfiles:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLocalIdentityProfiles.from_dict(response_dict)
-            else:
-                return ModelLocalIdentityProfiles.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLocalIdentityProfiles.from_dict(response_dict)
+                else:
+                    return ModelLocalIdentityProfiles.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -75,11 +75,11 @@ class LocalIdentityIdentityProfiles:
         else:
             if response.status_code == 201:
                 self.logger.info("Local identity profile created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLocalIdentityProfile.from_dict(response_dict)
-            else:
-                return ModelLocalIdentityProfile.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLocalIdentityProfile.from_dict(response_dict)
+                else:
+                    return ModelLocalIdentityProfile.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -107,11 +107,11 @@ class LocalIdentityIdentityProfiles:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLocalIdentityProfile.from_dict(response_dict)
-            else:
-                return ModelLocalIdentityProfile.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLocalIdentityProfile.from_dict(response_dict)
+                else:
+                    return ModelLocalIdentityProfile.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -138,11 +138,11 @@ class LocalIdentityIdentityProfiles:
         else:
             if response.status_code == 200:
                 self.logger.info("Local identity profile updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelLocalIdentityProfile.from_dict(response_dict)
-            else:
-                return ModelLocalIdentityProfile.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelLocalIdentityProfile.from_dict(response_dict)
+                else:
+                    return ModelLocalIdentityProfile.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/metadata_urls.py
+++ b/pingfedsdk/apis/metadata_urls.py
@@ -46,11 +46,11 @@ class MetadataUrls:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataUrl.from_dict(response_dict)
-            else:
-                return ModelMetadataUrl.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataUrl.from_dict(response_dict)
+                else:
+                    return ModelMetadataUrl.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -77,11 +77,11 @@ class MetadataUrls:
         else:
             if response.status_code == 200:
                 self.logger.info("Metadata URL updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataUrl.from_dict(response_dict)
-            else:
-                return ModelMetadataUrl.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataUrl.from_dict(response_dict)
+                else:
+                    return ModelMetadataUrl.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -141,11 +141,11 @@ class MetadataUrls:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataUrls.from_dict(response_dict)
-            else:
-                return ModelMetadataUrls.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataUrls.from_dict(response_dict)
+                else:
+                    return ModelMetadataUrls.from_dict(response.json())
 
     def addMetadataUrl(self, body: ModelMetadataUrl):
         """ Add a new Metadata URL.
@@ -168,11 +168,11 @@ class MetadataUrls:
         else:
             if response.status_code == 201:
                 self.logger.info("Metadata URL added.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataUrl.from_dict(response_dict)
-            else:
-                return ModelMetadataUrl.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataUrl.from_dict(response_dict)
+                else:
+                    return ModelMetadataUrl.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/notification_publishers.py
+++ b/pingfedsdk/apis/notification_publishers.py
@@ -54,11 +54,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublishersSettings.from_dict(response_dict)
-            else:
-                return ModelNotificationPublishersSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublishersSettings.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublishersSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelNotificationPublishersSettings):
         """ Update general notification publisher settings.
@@ -81,11 +81,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Notification publisher settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublishersSettings.from_dict(response_dict)
-            else:
-                return ModelNotificationPublishersSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublishersSettings.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublishersSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -113,11 +113,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAction.from_dict(response_dict)
-            else:
-                return ModelAction.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAction.from_dict(response_dict)
+                else:
+                    return ModelAction.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -143,11 +143,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublisherDescriptors.from_dict(response_dict)
-            else:
-                return ModelNotificationPublisherDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublisherDescriptors.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublisherDescriptors.from_dict(response.json())
 
     def getNotificationPublisherPluginDescriptor(self, id: str):
         """ Get the description of a notification publisher plugin descriptor.
@@ -169,11 +169,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublisherDescriptor.from_dict(response_dict)
-            else:
-                return ModelNotificationPublisherDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublisherDescriptor.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublisherDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -199,11 +199,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublishers.from_dict(response_dict)
-            else:
-                return ModelNotificationPublishers.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublishers.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublishers.from_dict(response.json())
 
     def createNotificationPublisher(self, body: ModelNotificationPublisher):
         """ Create a notification publisher plugin instance.
@@ -226,11 +226,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 201:
                 self.logger.info("Notification Publisher plugin created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublisher.from_dict(response_dict)
-            else:
-                return ModelNotificationPublisher.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublisher.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublisher.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -258,11 +258,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublisher.from_dict(response_dict)
-            else:
-                return ModelNotificationPublisher.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublisher.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublisher.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -289,11 +289,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Notification Publisher plugin updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationPublisher.from_dict(response_dict)
-            else:
-                return ModelNotificationPublisher.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationPublisher.from_dict(response_dict)
+                else:
+                    return ModelNotificationPublisher.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -356,11 +356,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Notification Publisher plugin action invoked.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActionResult.from_dict(response_dict)
-            else:
-                return ModelActionResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActionResult.from_dict(response_dict)
+                else:
+                    return ModelActionResult.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -386,11 +386,11 @@ class NotificationPublishers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActions.from_dict(response_dict)
-            else:
-                return ModelActions.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActions.from_dict(response_dict)
+                else:
+                    return ModelActions.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_access_token_managers.py
+++ b/pingfedsdk/apis/oauth_access_token_managers.py
@@ -50,11 +50,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManagementSettings.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManagementSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManagementSettings.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManagementSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelAccessTokenManagementSettings):
         """ Update general access token management settings.
@@ -77,11 +77,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManagementSettings.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManagementSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManagementSettings.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManagementSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -109,11 +109,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManager.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManager.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManager.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManager.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -140,11 +140,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Access Token Management instance updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManager.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManager.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManager.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManager.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -206,11 +206,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManagerDescriptors.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManagerDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManagerDescriptors.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManagerDescriptors.from_dict(response.json())
 
     def getTokenManagerDescriptor(self, id: str):
         """ Get the description of a token management plugin descriptor.
@@ -232,11 +232,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManagerDescriptor.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManagerDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManagerDescriptor.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManagerDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -262,11 +262,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManagers.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManagers.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManagers.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManagers.from_dict(response.json())
 
     def createTokenManager(self, body: ModelAccessTokenManager):
         """ Create a token management plugin instance.
@@ -289,11 +289,11 @@ class OauthAccessTokenManagers:
         else:
             if response.status_code == 201:
                 self.logger.info("Access Token Management instance created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenManager.from_dict(response_dict)
-            else:
-                return ModelAccessTokenManager.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenManager.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenManager.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_access_token_mappings.py
+++ b/pingfedsdk/apis/oauth_access_token_mappings.py
@@ -46,11 +46,11 @@ class OauthAccessTokenMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenMapping.from_dict(response_dict)
-            else:
-                return ModelAccessTokenMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenMapping.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -77,11 +77,11 @@ class OauthAccessTokenMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Access token attribute mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenMapping.from_dict(response_dict)
-            else:
-                return ModelAccessTokenMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenMapping.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -139,11 +139,11 @@ class OauthAccessTokenMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenMappings.from_dict(response_dict)
-            else:
-                return ModelAccessTokenMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenMappings.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenMappings.from_dict(response.json())
 
     def createMapping(self, body: ModelAccessTokenMapping, XBypassExternalValidation: bool = None):
         """ Create a new Access Token Mapping.
@@ -166,11 +166,11 @@ class OauthAccessTokenMappings:
         else:
             if response.status_code == 201:
                 self.logger.info("Access token attribute mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAccessTokenMapping.from_dict(response_dict)
-            else:
-                return ModelAccessTokenMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAccessTokenMapping.from_dict(response_dict)
+                else:
+                    return ModelAccessTokenMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_auth_server_settings.py
+++ b/pingfedsdk/apis/oauth_auth_server_settings.py
@@ -47,11 +47,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthorizationServerSettings.from_dict(response_dict)
-            else:
-                return ModelAuthorizationServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthorizationServerSettings.from_dict(response_dict)
+                else:
+                    return ModelAuthorizationServerSettings.from_dict(response.json())
 
     def updateAuthorizationServerSettings(self, body: ModelAuthorizationServerSettings):
         """ Update the Authorization Server Settings.
@@ -74,11 +74,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Authorization Server Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthorizationServerSettings.from_dict(response_dict)
-            else:
-                return ModelAuthorizationServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthorizationServerSettings.from_dict(response_dict)
+                else:
+                    return ModelAuthorizationServerSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -107,11 +107,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 201:
                 self.logger.info("Common Scope added.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeEntry.from_dict(response_dict)
-            else:
-                return ModelScopeEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeEntry.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -139,11 +139,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeEntry.from_dict(response_dict)
-            else:
-                return ModelScopeEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeEntry.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -170,11 +170,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Common Scope updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeEntry.from_dict(response_dict)
-            else:
-                return ModelScopeEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeEntry.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -231,11 +231,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 201:
                 self.logger.info("Common Scope Group created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeGroupEntry.from_dict(response_dict)
-            else:
-                return ModelScopeGroupEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeGroupEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeGroupEntry.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -263,11 +263,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeGroupEntry.from_dict(response_dict)
-            else:
-                return ModelScopeGroupEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeGroupEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeGroupEntry.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -294,11 +294,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Common Scope Group updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeGroupEntry.from_dict(response_dict)
-            else:
-                return ModelScopeGroupEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeGroupEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeGroupEntry.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -359,11 +359,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 201:
                 self.logger.info("Exclusive Scope added.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeEntry.from_dict(response_dict)
-            else:
-                return ModelScopeEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeEntry.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -395,11 +395,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeEntry.from_dict(response_dict)
-            else:
-                return ModelScopeEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeEntry.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -426,11 +426,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Exclusive Scope updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeEntry.from_dict(response_dict)
-            else:
-                return ModelScopeEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeEntry.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -485,11 +485,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 201:
                 self.logger.info("Exclusive Scope Group created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeGroupEntry.from_dict(response_dict)
-            else:
-                return ModelScopeGroupEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeGroupEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeGroupEntry.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -517,11 +517,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeGroupEntry.from_dict(response_dict)
-            else:
-                return ModelScopeGroupEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeGroupEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeGroupEntry.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -548,11 +548,11 @@ class OauthAuthServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Exclusive Scope Group updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelScopeGroupEntry.from_dict(response_dict)
-            else:
-                return ModelScopeGroupEntry.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelScopeGroupEntry.from_dict(response_dict)
+                else:
+                    return ModelScopeGroupEntry.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_authentication_policy_contract_mappings.py
+++ b/pingfedsdk/apis/oauth_authentication_policy_contract_mappings.py
@@ -46,11 +46,11 @@ class OauthAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToPersistentGrantMappings.from_dict(response_dict)
-            else:
-                return ModelApcToPersistentGrantMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToPersistentGrantMappings.from_dict(response_dict)
+                else:
+                    return ModelApcToPersistentGrantMappings.from_dict(response.json())
 
     def createApcMapping(self, body: ModelApcToPersistentGrantMapping, XBypassExternalValidation: bool = None):
         """ Create a new authentication policy contract to persistent grant mapping.
@@ -73,11 +73,11 @@ class OauthAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication policy contract to persistent grant mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToPersistentGrantMapping.from_dict(response_dict)
-            else:
-                return ModelApcToPersistentGrantMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToPersistentGrantMapping.from_dict(response_dict)
+                else:
+                    return ModelApcToPersistentGrantMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class OauthAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToPersistentGrantMapping.from_dict(response_dict)
-            else:
-                return ModelApcToPersistentGrantMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToPersistentGrantMapping.from_dict(response_dict)
+                else:
+                    return ModelApcToPersistentGrantMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class OauthAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication policy contract to persistent grant mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToPersistentGrantMapping.from_dict(response_dict)
-            else:
-                return ModelApcToPersistentGrantMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToPersistentGrantMapping.from_dict(response_dict)
+                else:
+                    return ModelApcToPersistentGrantMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_ciba_server_policy.py
+++ b/pingfedsdk/apis/oauth_ciba_server_policy.py
@@ -47,11 +47,11 @@ class OauthCibaServerPolicy:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCibaServerPolicySettings.from_dict(response_dict)
-            else:
-                return ModelCibaServerPolicySettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCibaServerPolicySettings.from_dict(response_dict)
+                else:
+                    return ModelCibaServerPolicySettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelCibaServerPolicySettings, XBypassExternalValidation: bool = None):
         """ Update general ciba server request policy settings.
@@ -74,11 +74,11 @@ class OauthCibaServerPolicy:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCibaServerPolicySettings.from_dict(response_dict)
-            else:
-                return ModelCibaServerPolicySettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCibaServerPolicySettings.from_dict(response_dict)
+                else:
+                    return ModelCibaServerPolicySettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -106,11 +106,11 @@ class OauthCibaServerPolicy:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelRequestPolicy.from_dict(response_dict)
-            else:
-                return ModelRequestPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelRequestPolicy.from_dict(response_dict)
+                else:
+                    return ModelRequestPolicy.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -137,11 +137,11 @@ class OauthCibaServerPolicy:
         else:
             if response.status_code == 200:
                 self.logger.info("Request Handling Policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelRequestPolicy.from_dict(response_dict)
-            else:
-                return ModelRequestPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelRequestPolicy.from_dict(response_dict)
+                else:
+                    return ModelRequestPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -201,11 +201,11 @@ class OauthCibaServerPolicy:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelRequestPolicies.from_dict(response_dict)
-            else:
-                return ModelRequestPolicies.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelRequestPolicies.from_dict(response_dict)
+                else:
+                    return ModelRequestPolicies.from_dict(response.json())
 
     def createPolicy(self, body: ModelRequestPolicy, XBypassExternalValidation: bool = None):
         """ Create a new request policy.
@@ -228,11 +228,11 @@ class OauthCibaServerPolicy:
         else:
             if response.status_code == 201:
                 self.logger.info("Request Handling Policy created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelRequestPolicy.from_dict(response_dict)
-            else:
-                return ModelRequestPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelRequestPolicy.from_dict(response_dict)
+                else:
+                    return ModelRequestPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_client_registration_policies.py
+++ b/pingfedsdk/apis/oauth_client_registration_policies.py
@@ -49,11 +49,11 @@ class OauthClientRegistrationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientRegistrationPolicyDescriptors.from_dict(response_dict)
-            else:
-                return ModelClientRegistrationPolicyDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientRegistrationPolicyDescriptors.from_dict(response_dict)
+                else:
+                    return ModelClientRegistrationPolicyDescriptors.from_dict(response.json())
 
     def getDynamicClientRegistrationDescriptor(self, id: str):
         """ Get the description of a client registration policy plugin descriptor.
@@ -75,11 +75,11 @@ class OauthClientRegistrationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientRegistrationPolicyDescriptor.from_dict(response_dict)
-            else:
-                return ModelClientRegistrationPolicyDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientRegistrationPolicyDescriptor.from_dict(response_dict)
+                else:
+                    return ModelClientRegistrationPolicyDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class OauthClientRegistrationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientRegistrationPolicies.from_dict(response_dict)
-            else:
-                return ModelClientRegistrationPolicies.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientRegistrationPolicies.from_dict(response_dict)
+                else:
+                    return ModelClientRegistrationPolicies.from_dict(response.json())
 
     def createDynamicClientRegistrationPolicy(self, body: ModelClientRegistrationPolicy):
         """ Create a client registration policy plugin instance.
@@ -132,11 +132,11 @@ class OauthClientRegistrationPolicies:
         else:
             if response.status_code == 201:
                 self.logger.info("Client Registration Policy plugin created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientRegistrationPolicy.from_dict(response_dict)
-            else:
-                return ModelClientRegistrationPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientRegistrationPolicy.from_dict(response_dict)
+                else:
+                    return ModelClientRegistrationPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -164,11 +164,11 @@ class OauthClientRegistrationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientRegistrationPolicy.from_dict(response_dict)
-            else:
-                return ModelClientRegistrationPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientRegistrationPolicy.from_dict(response_dict)
+                else:
+                    return ModelClientRegistrationPolicy.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -195,11 +195,11 @@ class OauthClientRegistrationPolicies:
         else:
             if response.status_code == 200:
                 self.logger.info("Client Registration Policy plugin updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientRegistrationPolicy.from_dict(response_dict)
-            else:
-                return ModelClientRegistrationPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientRegistrationPolicy.from_dict(response_dict)
+                else:
+                    return ModelClientRegistrationPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_client_settings.py
+++ b/pingfedsdk/apis/oauth_client_settings.py
@@ -43,11 +43,11 @@ class OauthClientSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientSettings.from_dict(response_dict)
-            else:
-                return ModelClientSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientSettings.from_dict(response_dict)
+                else:
+                    return ModelClientSettings.from_dict(response.json())
 
     def updateClientSettings(self, body: ModelClientSettings):
         """ Update the client settings.
@@ -70,11 +70,11 @@ class OauthClientSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Client Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientSettings.from_dict(response_dict)
-            else:
-                return ModelClientSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientSettings.from_dict(response_dict)
+                else:
+                    return ModelClientSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_clients.py
+++ b/pingfedsdk/apis/oauth_clients.py
@@ -47,11 +47,11 @@ class OauthClients:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientSecret.from_dict(response_dict)
-            else:
-                return ModelClientSecret.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientSecret.from_dict(response_dict)
+                else:
+                    return ModelClientSecret.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -84,11 +84,11 @@ class OauthClients:
         else:
             if response.status_code == 200:
                 self.logger.info("Client updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClientSecret.from_dict(response_dict)
-            else:
-                return ModelClientSecret.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClientSecret.from_dict(response_dict)
+                else:
+                    return ModelClientSecret.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -120,11 +120,11 @@ class OauthClients:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClients.from_dict(response_dict)
-            else:
-                return ModelClients.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClients.from_dict(response_dict)
+                else:
+                    return ModelClients.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -149,11 +149,11 @@ class OauthClients:
         else:
             if response.status_code == 201:
                 self.logger.info("Client created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClient.from_dict(response_dict)
-            else:
-                return ModelClient.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClient.from_dict(response_dict)
+                else:
+                    return ModelClient.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -181,11 +181,11 @@ class OauthClients:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClient.from_dict(response_dict)
-            else:
-                return ModelClient.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClient.from_dict(response_dict)
+                else:
+                    return ModelClient.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -212,11 +212,11 @@ class OauthClients:
         else:
             if response.status_code == 200:
                 self.logger.info("Client updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelClient.from_dict(response_dict)
-            else:
-                return ModelClient.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelClient.from_dict(response_dict)
+                else:
+                    return ModelClient.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_idp_adapter_mappings.py
+++ b/pingfedsdk/apis/oauth_idp_adapter_mappings.py
@@ -46,11 +46,11 @@ class OauthIdpAdapterMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapterMappings.from_dict(response_dict)
-            else:
-                return ModelIdpAdapterMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapterMappings.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapterMappings.from_dict(response.json())
 
     def createIdpAdapterMapping(self, body: ModelIdpAdapterMapping, XBypassExternalValidation: bool = None):
         """ Create a new IdP adapter mapping.
@@ -73,11 +73,11 @@ class OauthIdpAdapterMappings:
         else:
             if response.status_code == 201:
                 self.logger.info("IdP adapter mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelIdpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapterMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class OauthIdpAdapterMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelIdpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapterMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class OauthIdpAdapterMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("IdP adapter mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelIdpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelIdpAdapterMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_issuers.py
+++ b/pingfedsdk/apis/oauth_issuers.py
@@ -46,11 +46,11 @@ class OauthIssuers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIssuers.from_dict(response_dict)
-            else:
-                return ModelIssuers.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIssuers.from_dict(response_dict)
+                else:
+                    return ModelIssuers.from_dict(response.json())
 
     def addIssuer(self, body: ModelIssuer):
         """ Create a new virtual issuer.
@@ -73,11 +73,11 @@ class OauthIssuers:
         else:
             if response.status_code == 201:
                 self.logger.info("Issuer created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIssuer.from_dict(response_dict)
-            else:
-                return ModelIssuer.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIssuer.from_dict(response_dict)
+                else:
+                    return ModelIssuer.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class OauthIssuers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIssuer.from_dict(response_dict)
-            else:
-                return ModelIssuer.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIssuer.from_dict(response_dict)
+                else:
+                    return ModelIssuer.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class OauthIssuers:
         else:
             if response.status_code == 200:
                 self.logger.info("Issuer updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIssuer.from_dict(response_dict)
-            else:
-                return ModelIssuer.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIssuer.from_dict(response_dict)
+                else:
+                    return ModelIssuer.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_open_id_connect.py
+++ b/pingfedsdk/apis/oauth_open_id_connect.py
@@ -47,11 +47,11 @@ class OauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOpenIdConnectSettings.from_dict(response_dict)
-            else:
-                return ModelOpenIdConnectSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOpenIdConnectSettings.from_dict(response_dict)
+                else:
+                    return ModelOpenIdConnectSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelOpenIdConnectSettings):
         """ Set the OpenID Connect Settings.
@@ -74,11 +74,11 @@ class OauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOpenIdConnectSettings.from_dict(response_dict)
-            else:
-                return ModelOpenIdConnectSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOpenIdConnectSettings.from_dict(response_dict)
+                else:
+                    return ModelOpenIdConnectSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -106,11 +106,11 @@ class OauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOpenIdConnectPolicy.from_dict(response_dict)
-            else:
-                return ModelOpenIdConnectPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOpenIdConnectPolicy.from_dict(response_dict)
+                else:
+                    return ModelOpenIdConnectPolicy.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -137,11 +137,11 @@ class OauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOpenIdConnectPolicy.from_dict(response_dict)
-            else:
-                return ModelOpenIdConnectPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOpenIdConnectPolicy.from_dict(response_dict)
+                else:
+                    return ModelOpenIdConnectPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -201,11 +201,11 @@ class OauthOpenIdConnect:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOpenIdConnectPolicies.from_dict(response_dict)
-            else:
-                return ModelOpenIdConnectPolicies.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOpenIdConnectPolicies.from_dict(response_dict)
+                else:
+                    return ModelOpenIdConnectPolicies.from_dict(response.json())
 
     def createPolicy(self, body: ModelOpenIdConnectPolicy, XBypassExternalValidation: bool = None):
         """ Create a new OpenID Connect Policy.
@@ -228,11 +228,11 @@ class OauthOpenIdConnect:
         else:
             if response.status_code == 201:
                 self.logger.info("Policy created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOpenIdConnectPolicy.from_dict(response_dict)
-            else:
-                return ModelOpenIdConnectPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOpenIdConnectPolicy.from_dict(response_dict)
+                else:
+                    return ModelOpenIdConnectPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_out_of_band_auth_plugins.py
+++ b/pingfedsdk/apis/oauth_out_of_band_auth_plugins.py
@@ -53,11 +53,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAction.from_dict(response_dict)
-            else:
-                return ModelAction.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAction.from_dict(response_dict)
+                else:
+                    return ModelAction.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -84,11 +84,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Action invoked on Out of Band authenticator.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActionResult.from_dict(response_dict)
-            else:
-                return ModelActionResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActionResult.from_dict(response_dict)
+                else:
+                    return ModelActionResult.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -114,11 +114,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutOfBandAuthPluginDescriptors.from_dict(response_dict)
-            else:
-                return ModelOutOfBandAuthPluginDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutOfBandAuthPluginDescriptors.from_dict(response_dict)
+                else:
+                    return ModelOutOfBandAuthPluginDescriptors.from_dict(response.json())
 
     def getOOBAuthPluginDescriptor(self, id: str):
         """ Get the descriptor of an Out of Band authenticator plugin.
@@ -140,11 +140,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutOfBandAuthPluginDescriptor.from_dict(response_dict)
-            else:
-                return ModelOutOfBandAuthPluginDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutOfBandAuthPluginDescriptor.from_dict(response_dict)
+                else:
+                    return ModelOutOfBandAuthPluginDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -170,11 +170,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutOfBandAuthenticators.from_dict(response_dict)
-            else:
-                return ModelOutOfBandAuthenticators.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutOfBandAuthenticators.from_dict(response_dict)
+                else:
+                    return ModelOutOfBandAuthenticators.from_dict(response.json())
 
     def createOOBAuthenticator(self, body: ModelOutOfBandAuthenticator):
         """ Create an Out of Band authenticator plugin instance.
@@ -197,11 +197,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 201:
                 self.logger.info("Out of Band Authenticator created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutOfBandAuthenticator.from_dict(response_dict)
-            else:
-                return ModelOutOfBandAuthenticator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutOfBandAuthenticator.from_dict(response_dict)
+                else:
+                    return ModelOutOfBandAuthenticator.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -229,11 +229,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutOfBandAuthenticator.from_dict(response_dict)
-            else:
-                return ModelOutOfBandAuthenticator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutOfBandAuthenticator.from_dict(response_dict)
+                else:
+                    return ModelOutOfBandAuthenticator.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -260,11 +260,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Out of Band Authenticator updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutOfBandAuthenticator.from_dict(response_dict)
-            else:
-                return ModelOutOfBandAuthenticator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutOfBandAuthenticator.from_dict(response_dict)
+                else:
+                    return ModelOutOfBandAuthenticator.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -326,11 +326,11 @@ class OauthOutOfBandAuthPlugins:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActions.from_dict(response_dict)
-            else:
-                return ModelActions.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActions.from_dict(response_dict)
+                else:
+                    return ModelActions.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_resource_owner_credentials_mappings.py
+++ b/pingfedsdk/apis/oauth_resource_owner_credentials_mappings.py
@@ -46,11 +46,11 @@ class OauthResourceOwnerCredentialsMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelResourceOwnerCredentialsMappings.from_dict(response_dict)
-            else:
-                return ModelResourceOwnerCredentialsMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelResourceOwnerCredentialsMappings.from_dict(response_dict)
+                else:
+                    return ModelResourceOwnerCredentialsMappings.from_dict(response.json())
 
     def createResourceOwnerCredentialsMapping(self, body: ModelResourceOwnerCredentialsMapping, XBypassExternalValidation: bool = None):
         """ Create a new Resource Owner Credentials mapping.
@@ -73,11 +73,11 @@ class OauthResourceOwnerCredentialsMappings:
         else:
             if response.status_code == 201:
                 self.logger.info("Resource owner credentials mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelResourceOwnerCredentialsMapping.from_dict(response_dict)
-            else:
-                return ModelResourceOwnerCredentialsMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelResourceOwnerCredentialsMapping.from_dict(response_dict)
+                else:
+                    return ModelResourceOwnerCredentialsMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class OauthResourceOwnerCredentialsMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelResourceOwnerCredentialsMapping.from_dict(response_dict)
-            else:
-                return ModelResourceOwnerCredentialsMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelResourceOwnerCredentialsMapping.from_dict(response_dict)
+                else:
+                    return ModelResourceOwnerCredentialsMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class OauthResourceOwnerCredentialsMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Resource owner credentials mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelResourceOwnerCredentialsMapping.from_dict(response_dict)
-            else:
-                return ModelResourceOwnerCredentialsMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelResourceOwnerCredentialsMapping.from_dict(response_dict)
+                else:
+                    return ModelResourceOwnerCredentialsMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_token_exchange_generator.py
+++ b/pingfedsdk/apis/oauth_token_exchange_generator.py
@@ -47,11 +47,11 @@ class OauthTokenExchangeGenerator:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeGeneratorSettings.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeGeneratorSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeGeneratorSettings.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeGeneratorSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelTokenExchangeGeneratorSettings, bypassExternalValidation: bool = None):
         """ Update general OAuth 2.0 Token Exchange Generator settings.
@@ -74,11 +74,11 @@ class OauthTokenExchangeGenerator:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeGeneratorSettings.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeGeneratorSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeGeneratorSettings.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeGeneratorSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -106,11 +106,11 @@ class OauthTokenExchangeGenerator:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeGeneratorGroups.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeGeneratorGroups.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeGeneratorGroups.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeGeneratorGroups.from_dict(response.json())
 
     def createGroup(self, body: ModelTokenExchangeGeneratorGroup, bypassExternalValidation: bool = None):
         """ Create a new OAuth 2.0 Token Exchange Generator group.
@@ -133,11 +133,11 @@ class OauthTokenExchangeGenerator:
         else:
             if response.status_code == 201:
                 self.logger.info("Token Exchange Processor Policy created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeGeneratorGroup.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeGeneratorGroup.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeGeneratorGroup.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeGeneratorGroup.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -165,11 +165,11 @@ class OauthTokenExchangeGenerator:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeGeneratorGroup.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeGeneratorGroup.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeGeneratorGroup.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeGeneratorGroup.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -196,11 +196,11 @@ class OauthTokenExchangeGenerator:
         else:
             if response.status_code == 200:
                 self.logger.info("Token Exchange Processor Policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeGeneratorGroup.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeGeneratorGroup.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeGeneratorGroup.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeGeneratorGroup.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_token_exchange_processor.py
+++ b/pingfedsdk/apis/oauth_token_exchange_processor.py
@@ -47,11 +47,11 @@ class OauthTokenExchangeProcessor:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeProcessorSettings.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeProcessorSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeProcessorSettings.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeProcessorSettings.from_dict(response.json())
 
     def updateSettings(self, body: ModelTokenExchangeProcessorSettings, bypassExternalValidation: bool = None):
         """ Update general OAuth 2.0 Token Exchange Processor settings.
@@ -74,11 +74,11 @@ class OauthTokenExchangeProcessor:
         else:
             if response.status_code == 200:
                 self.logger.info("Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeProcessorSettings.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeProcessorSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeProcessorSettings.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeProcessorSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -106,11 +106,11 @@ class OauthTokenExchangeProcessor:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeProcessorPolicy.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeProcessorPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeProcessorPolicy.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeProcessorPolicy.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -137,11 +137,11 @@ class OauthTokenExchangeProcessor:
         else:
             if response.status_code == 200:
                 self.logger.info("Token Exchange Processor Policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeProcessorPolicy.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeProcessorPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeProcessorPolicy.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeProcessorPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -201,11 +201,11 @@ class OauthTokenExchangeProcessor:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeProcessorPolicies.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeProcessorPolicies.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeProcessorPolicies.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeProcessorPolicies.from_dict(response.json())
 
     def createPolicy(self, body: ModelTokenExchangeProcessorPolicy, bypassExternalValidation: bool = None):
         """ Create a new OAuth 2.0 Token Exchange Processor policy.
@@ -228,11 +228,11 @@ class OauthTokenExchangeProcessor:
         else:
             if response.status_code == 201:
                 self.logger.info("Token Exchange Processor Policy created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenExchangeProcessorPolicy.from_dict(response_dict)
-            else:
-                return ModelTokenExchangeProcessorPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenExchangeProcessorPolicy.from_dict(response_dict)
+                else:
+                    return ModelTokenExchangeProcessorPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/oauth_token_exchange_token_generator_mappings.py
+++ b/pingfedsdk/apis/oauth_token_exchange_token_generator_mappings.py
@@ -46,11 +46,11 @@ class OauthTokenExchangeTokenGeneratorMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelProcessorPolicyToGeneratorMappings.from_dict(response_dict)
-            else:
-                return ModelProcessorPolicyToGeneratorMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelProcessorPolicyToGeneratorMappings.from_dict(response_dict)
+                else:
+                    return ModelProcessorPolicyToGeneratorMappings.from_dict(response.json())
 
     def createTokenGeneratorMapping(self, body: ModelProcessorPolicyToGeneratorMapping, XBypassExternalValidation: bool = None):
         """ Create a new Token Exchange Processor policy to Token Generator Mapping.
@@ -73,11 +73,11 @@ class OauthTokenExchangeTokenGeneratorMappings:
         else:
             if response.status_code == 201:
                 self.logger.info("Token Exchange Processor policy to Token Generator mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelProcessorPolicyToGeneratorMapping.from_dict(response_dict)
-            else:
-                return ModelProcessorPolicyToGeneratorMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelProcessorPolicyToGeneratorMapping.from_dict(response_dict)
+                else:
+                    return ModelProcessorPolicyToGeneratorMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class OauthTokenExchangeTokenGeneratorMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelProcessorPolicyToGeneratorMapping.from_dict(response_dict)
-            else:
-                return ModelProcessorPolicyToGeneratorMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelProcessorPolicyToGeneratorMapping.from_dict(response_dict)
+                else:
+                    return ModelProcessorPolicyToGeneratorMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class OauthTokenExchangeTokenGeneratorMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Token Exchange Processor policy to Token Generator mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelProcessorPolicyToGeneratorMapping.from_dict(response_dict)
-            else:
-                return ModelProcessorPolicyToGeneratorMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelProcessorPolicyToGeneratorMapping.from_dict(response_dict)
+                else:
+                    return ModelProcessorPolicyToGeneratorMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/password_credential_validators.py
+++ b/pingfedsdk/apis/password_credential_validators.py
@@ -48,11 +48,11 @@ class PasswordCredentialValidators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPasswordCredentialValidator.from_dict(response_dict)
-            else:
-                return ModelPasswordCredentialValidator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPasswordCredentialValidator.from_dict(response_dict)
+                else:
+                    return ModelPasswordCredentialValidator.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -79,11 +79,11 @@ class PasswordCredentialValidators:
         else:
             if response.status_code == 200:
                 self.logger.info("Password credential validator updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPasswordCredentialValidator.from_dict(response_dict)
-            else:
-                return ModelPasswordCredentialValidator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPasswordCredentialValidator.from_dict(response_dict)
+                else:
+                    return ModelPasswordCredentialValidator.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -143,11 +143,11 @@ class PasswordCredentialValidators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPasswordCredentialValidatorDescriptors.from_dict(response_dict)
-            else:
-                return ModelPasswordCredentialValidatorDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPasswordCredentialValidatorDescriptors.from_dict(response_dict)
+                else:
+                    return ModelPasswordCredentialValidatorDescriptors.from_dict(response.json())
 
     def getPasswordCredentialValidatorDescriptor(self, id: str):
         """ Get the description of a password credential validator by ID.
@@ -169,11 +169,11 @@ class PasswordCredentialValidators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPasswordCredentialValidatorDescriptor.from_dict(response_dict)
-            else:
-                return ModelPasswordCredentialValidatorDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPasswordCredentialValidatorDescriptor.from_dict(response_dict)
+                else:
+                    return ModelPasswordCredentialValidatorDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -199,11 +199,11 @@ class PasswordCredentialValidators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPasswordCredentialValidators.from_dict(response_dict)
-            else:
-                return ModelPasswordCredentialValidators.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPasswordCredentialValidators.from_dict(response_dict)
+                else:
+                    return ModelPasswordCredentialValidators.from_dict(response.json())
 
     def createPasswordCredentialValidator(self, body: ModelPasswordCredentialValidator):
         """ Create a new password credential validator instance
@@ -226,11 +226,11 @@ class PasswordCredentialValidators:
         else:
             if response.status_code == 201:
                 self.logger.info("Password credential validator created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPasswordCredentialValidator.from_dict(response_dict)
-            else:
-                return ModelPasswordCredentialValidator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPasswordCredentialValidator.from_dict(response_dict)
+                else:
+                    return ModelPasswordCredentialValidator.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/ping_one_connections.py
+++ b/pingfedsdk/apis/ping_one_connections.py
@@ -51,11 +51,11 @@ class PingOneConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneConnection.from_dict(response_dict)
-            else:
-                return ModelPingOneConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneConnection.from_dict(response_dict)
+                else:
+                    return ModelPingOneConnection.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -82,11 +82,11 @@ class PingOneConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("PingOne connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneConnection.from_dict(response_dict)
-            else:
-                return ModelPingOneConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneConnection.from_dict(response_dict)
+                else:
+                    return ModelPingOneConnection.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -146,11 +146,11 @@ class PingOneConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelServiceAssociations.from_dict(response_dict)
-            else:
-                return ModelServiceAssociations.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelServiceAssociations.from_dict(response_dict)
+                else:
+                    return ModelServiceAssociations.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -176,11 +176,11 @@ class PingOneConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneConnections.from_dict(response_dict)
-            else:
-                return ModelPingOneConnections.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneConnections.from_dict(response_dict)
+                else:
+                    return ModelPingOneConnections.from_dict(response.json())
 
     def createPingOneConnection(self, body: ModelPingOneConnection, XBypassExternalValidation: bool = None):
         """ Create a new PingOne connection.
@@ -203,11 +203,11 @@ class PingOneConnections:
         else:
             if response.status_code == 201:
                 self.logger.info("PingOne connection created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneConnection.from_dict(response_dict)
-            else:
-                return ModelPingOneConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneConnection.from_dict(response_dict)
+                else:
+                    return ModelPingOneConnection.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -235,11 +235,11 @@ class PingOneConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneEnvironments.from_dict(response_dict)
-            else:
-                return ModelPingOneEnvironments.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneEnvironments.from_dict(response_dict)
+                else:
+                    return ModelPingOneEnvironments.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -269,11 +269,11 @@ class PingOneConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelResourceUsages.from_dict(response_dict)
-            else:
-                return ModelResourceUsages.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelResourceUsages.from_dict(response_dict)
+                else:
+                    return ModelResourceUsages.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -299,11 +299,11 @@ class PingOneConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneCredentialStatus.from_dict(response_dict)
-            else:
-                return ModelPingOneCredentialStatus.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneCredentialStatus.from_dict(response_dict)
+                else:
+                    return ModelPingOneCredentialStatus.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/ping_one_for_enterprise.py
+++ b/pingfedsdk/apis/ping_one_for_enterprise.py
@@ -44,11 +44,11 @@ class PingOneForEnterprise:
         else:
             if response.status_code == 200:
                 self.logger.info("Disconnected from PingOne for Enterprise")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
-            else:
-                return ModelPingOneForEnterpriseSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
+                else:
+                    return ModelPingOneForEnterpriseSettings.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) PingFederate is not connected to PingOne for Enterprise. Operation not available."
                 self.logger.info(message)
@@ -76,11 +76,11 @@ class PingOneForEnterprise:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelP14EKeysView.from_dict(response_dict)
-            else:
-                return ModelP14EKeysView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelP14EKeysView.from_dict(response_dict)
+                else:
+                    return ModelP14EKeysView.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) PingFederate is not connected to PingOne for Enterprise. Operation not available."
                 self.logger.info(message)
@@ -106,11 +106,11 @@ class PingOneForEnterprise:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
-            else:
-                return ModelPingOneForEnterpriseSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
+                else:
+                    return ModelPingOneForEnterpriseSettings.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) PingFederate is not connected to PingOne for Enterprise. Operation not available."
                 self.logger.info(message)
@@ -137,11 +137,11 @@ class PingOneForEnterprise:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
-            else:
-                return ModelPingOneForEnterpriseSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
+                else:
+                    return ModelPingOneForEnterpriseSettings.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) PingFederate is not connected to PingOne for Enterprise. Operation not available."
                 self.logger.info(message)
@@ -169,11 +169,11 @@ class PingOneForEnterprise:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
-            else:
-                return ModelPingOneForEnterpriseSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelPingOneForEnterpriseSettings.from_dict(response_dict)
+                else:
+                    return ModelPingOneForEnterpriseSettings.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) PingFederate is not connected to PingOne for Enterprise. Operation not available."
                 self.logger.info(message)
@@ -201,11 +201,11 @@ class PingOneForEnterprise:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelP14EKeysView.from_dict(response_dict)
-            else:
-                return ModelP14EKeysView.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelP14EKeysView.from_dict(response_dict)
+                else:
+                    return ModelP14EKeysView.from_dict(response.json())
             if response.status_code == 403:
                 message = "(403) PingFederate is not connected to PingOne for Enterprise. Operation not available."
                 self.logger.info(message)

--- a/pingfedsdk/apis/protocol_metadata.py
+++ b/pingfedsdk/apis/protocol_metadata.py
@@ -44,11 +44,11 @@ class ProtocolMetadata:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataLifetimeSettings.from_dict(response_dict)
-            else:
-                return ModelMetadataLifetimeSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataLifetimeSettings.from_dict(response_dict)
+                else:
+                    return ModelMetadataLifetimeSettings.from_dict(response.json())
 
     def updateLifetimeSettings(self, body: ModelMetadataLifetimeSettings):
         """ Update metadata cache duration and reload delay for automated reloading.
@@ -71,11 +71,11 @@ class ProtocolMetadata:
         else:
             if response.status_code == 200:
                 self.logger.info("Metadata lifetime settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataLifetimeSettings.from_dict(response_dict)
-            else:
-                return ModelMetadataLifetimeSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataLifetimeSettings.from_dict(response_dict)
+                else:
+                    return ModelMetadataLifetimeSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -103,11 +103,11 @@ class ProtocolMetadata:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataSigningSettings.from_dict(response_dict)
-            else:
-                return ModelMetadataSigningSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataSigningSettings.from_dict(response_dict)
+                else:
+                    return ModelMetadataSigningSettings.from_dict(response.json())
 
     def updateSigningSettings(self, body: ModelMetadataSigningSettings = None):
         """ Update the certificate and algorithm for metadata signing.
@@ -130,11 +130,11 @@ class ProtocolMetadata:
         else:
             if response.status_code == 200:
                 self.logger.info("Metadata signing settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelMetadataSigningSettings.from_dict(response_dict)
-            else:
-                return ModelMetadataSigningSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelMetadataSigningSettings.from_dict(response_dict)
+                else:
+                    return ModelMetadataSigningSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/redirect_validation.py
+++ b/pingfedsdk/apis/redirect_validation.py
@@ -43,11 +43,11 @@ class RedirectValidation:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelRedirectValidationSettings.from_dict(response_dict)
-            else:
-                return ModelRedirectValidationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelRedirectValidationSettings.from_dict(response_dict)
+                else:
+                    return ModelRedirectValidationSettings.from_dict(response.json())
 
     def updateRedirectValidationSettings(self, body: ModelRedirectValidationSettings):
         """ Update redirect validation settings.
@@ -70,11 +70,11 @@ class RedirectValidation:
         else:
             if response.status_code == 200:
                 self.logger.info("Redirect validation settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelRedirectValidationSettings.from_dict(response_dict)
-            else:
-                return ModelRedirectValidationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelRedirectValidationSettings.from_dict(response_dict)
+                else:
+                    return ModelRedirectValidationSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/secret_managers.py
+++ b/pingfedsdk/apis/secret_managers.py
@@ -53,11 +53,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAction.from_dict(response_dict)
-            else:
-                return ModelAction.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAction.from_dict(response_dict)
+                else:
+                    return ModelAction.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -83,11 +83,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSecretManager.from_dict(response_dict)
-            else:
-                return ModelSecretManager.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSecretManager.from_dict(response_dict)
+                else:
+                    return ModelSecretManager.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -114,11 +114,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Secret Manager plugin updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSecretManager.from_dict(response_dict)
-            else:
-                return ModelSecretManager.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSecretManager.from_dict(response_dict)
+                else:
+                    return ModelSecretManager.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -181,11 +181,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Secret Manager plugin action invoked.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActionResult.from_dict(response_dict)
-            else:
-                return ModelActionResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActionResult.from_dict(response_dict)
+                else:
+                    return ModelActionResult.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -211,11 +211,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSecretManagerDescriptors.from_dict(response_dict)
-            else:
-                return ModelSecretManagerDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSecretManagerDescriptors.from_dict(response_dict)
+                else:
+                    return ModelSecretManagerDescriptors.from_dict(response.json())
 
     def getSecretManagerPluginDescriptor(self, id: str):
         """ Get a secret manager plugin descriptor.
@@ -237,11 +237,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSecretManagerDescriptor.from_dict(response_dict)
-            else:
-                return ModelSecretManagerDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSecretManagerDescriptor.from_dict(response_dict)
+                else:
+                    return ModelSecretManagerDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -267,11 +267,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSecretManagers.from_dict(response_dict)
-            else:
-                return ModelSecretManagers.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSecretManagers.from_dict(response_dict)
+                else:
+                    return ModelSecretManagers.from_dict(response.json())
 
     def createSecretManager(self, body: ModelSecretManager):
         """ Create a secret manager plugin instance.
@@ -294,11 +294,11 @@ class SecretManagers:
         else:
             if response.status_code == 201:
                 self.logger.info("Secret Manager plugin created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSecretManager.from_dict(response_dict)
-            else:
-                return ModelSecretManager.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSecretManager.from_dict(response_dict)
+                else:
+                    return ModelSecretManager.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -326,11 +326,11 @@ class SecretManagers:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActions.from_dict(response_dict)
-            else:
-                return ModelActions.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActions.from_dict(response_dict)
+                else:
+                    return ModelActions.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/server_settings.py
+++ b/pingfedsdk/apis/server_settings.py
@@ -56,11 +56,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIssuerCerts.from_dict(response_dict)
-            else:
-                return ModelIssuerCerts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIssuerCerts.from_dict(response_dict)
+                else:
+                    return ModelIssuerCerts.from_dict(response.json())
 
     def importCertificate(self, body: ModelX509File):
         """ Import a new certificate.
@@ -83,11 +83,11 @@ class ServerSettings:
         else:
             if response.status_code == 201:
                 self.logger.info("New certificate has been imported to WS-Trust STS Settings")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApiResponse.from_dict(response_dict)
-            else:
-                return ModelApiResponse.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApiResponse.from_dict(response_dict)
+                else:
+                    return ModelApiResponse.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -115,11 +115,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCaptchaSettings.from_dict(response_dict)
-            else:
-                return ModelCaptchaSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCaptchaSettings.from_dict(response_dict)
+                else:
+                    return ModelCaptchaSettings.from_dict(response.json())
 
     def updateCaptchaSettings(self, body: ModelCaptchaSettings):
         """ Update the CAPTCHA settings.
@@ -142,11 +142,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Captcha settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelCaptchaSettings.from_dict(response_dict)
-            else:
-                return ModelCaptchaSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelCaptchaSettings.from_dict(response_dict)
+                else:
+                    return ModelCaptchaSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -174,11 +174,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationSettings.from_dict(response_dict)
-            else:
-                return ModelNotificationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationSettings.from_dict(response_dict)
+                else:
+                    return ModelNotificationSettings.from_dict(response.json())
 
     def updateNotificationSettings(self, body: ModelNotificationSettings):
         """ Update the notification settings.
@@ -201,11 +201,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Notifications updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelNotificationSettings.from_dict(response_dict)
-            else:
-                return ModelNotificationSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelNotificationSettings.from_dict(response_dict)
+                else:
+                    return ModelNotificationSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -233,11 +233,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApiResponse.from_dict(response_dict)
-            else:
-                return ModelApiResponse.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApiResponse.from_dict(response_dict)
+                else:
+                    return ModelApiResponse.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -291,11 +291,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSystemKeys.from_dict(response_dict)
-            else:
-                return ModelSystemKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSystemKeys.from_dict(response_dict)
+                else:
+                    return ModelSystemKeys.from_dict(response.json())
 
     def updateSystemKeys(self, body: ModelSystemKeys):
         """ Update the system keys.
@@ -318,11 +318,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("System keys updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSystemKeys.from_dict(response_dict)
-            else:
-                return ModelSystemKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSystemKeys.from_dict(response_dict)
+                else:
+                    return ModelSystemKeys.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -350,11 +350,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelServerSettings.from_dict(response_dict)
-            else:
-                return ModelServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelServerSettings.from_dict(response_dict)
+                else:
+                    return ModelServerSettings.from_dict(response.json())
 
     def updateServerSettings(self, body: ModelServerSettings):
         """ Update the server settings.
@@ -377,11 +377,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Server Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelServerSettings.from_dict(response_dict)
-            else:
-                return ModelServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelServerSettings.from_dict(response_dict)
+                else:
+                    return ModelServerSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -413,11 +413,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelEmailServerSettings.from_dict(response_dict)
-            else:
-                return ModelEmailServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelEmailServerSettings.from_dict(response_dict)
+                else:
+                    return ModelEmailServerSettings.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -444,11 +444,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Email Server updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelEmailServerSettings.from_dict(response_dict)
-            else:
-                return ModelEmailServerSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelEmailServerSettings.from_dict(response_dict)
+                else:
+                    return ModelEmailServerSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -480,18 +480,18 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("successful operation")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSystemKeys.from_dict(response_dict)
-            else:
-                return ModelSystemKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSystemKeys.from_dict(response_dict)
+                else:
+                    return ModelSystemKeys.from_dict(response.json())
             if response.status_code == 201:
                 self.logger.info("System Keys rotated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSystemKeys.from_dict(response_dict)
-            else:
-                return ModelSystemKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSystemKeys.from_dict(response_dict)
+                else:
+                    return ModelSystemKeys.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -519,11 +519,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutboundProvisionDatabase.from_dict(response_dict)
-            else:
-                return ModelOutboundProvisionDatabase.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutboundProvisionDatabase.from_dict(response_dict)
+                else:
+                    return ModelOutboundProvisionDatabase.from_dict(response.json())
 
     def updateOutBoundProvisioningSettings(self, body: ModelOutboundProvisionDatabase):
         """ Update database used for outbound provisioning
@@ -546,11 +546,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Database updated for outbound provisioning.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelOutboundProvisionDatabase.from_dict(response_dict)
-            else:
-                return ModelOutboundProvisionDatabase.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelOutboundProvisionDatabase.from_dict(response_dict)
+                else:
+                    return ModelOutboundProvisionDatabase.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -574,11 +574,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelWsTrustStsSettings.from_dict(response_dict)
-            else:
-                return ModelWsTrustStsSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelWsTrustStsSettings.from_dict(response_dict)
+                else:
+                    return ModelWsTrustStsSettings.from_dict(response.json())
 
     def updateWsTrustStsSettings(self, body: ModelWsTrustStsSettings):
         """ Update WS-Trust STS Settings.
@@ -601,11 +601,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Server Settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelWsTrustStsSettings.from_dict(response_dict)
-            else:
-                return ModelWsTrustStsSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelWsTrustStsSettings.from_dict(response_dict)
+                else:
+                    return ModelWsTrustStsSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -633,11 +633,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelGeneralSettings.from_dict(response_dict)
-            else:
-                return ModelGeneralSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelGeneralSettings.from_dict(response_dict)
+                else:
+                    return ModelGeneralSettings.from_dict(response.json())
 
     def updateGeneralSettings(self, body: ModelGeneralSettings):
         """ Update general settings.
@@ -660,11 +660,11 @@ class ServerSettings:
         else:
             if response.status_code == 200:
                 self.logger.info("General settings have been updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelGeneralSettings.from_dict(response_dict)
-            else:
-                return ModelGeneralSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelGeneralSettings.from_dict(response_dict)
+                else:
+                    return ModelGeneralSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/service_authentication.py
+++ b/pingfedsdk/apis/service_authentication.py
@@ -43,11 +43,11 @@ class ServiceAuthentication:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelServiceAuthentication.from_dict(response_dict)
-            else:
-                return ModelServiceAuthentication.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelServiceAuthentication.from_dict(response_dict)
+                else:
+                    return ModelServiceAuthentication.from_dict(response.json())
 
     def updateServiceAuthentication(self, body: ModelServiceAuthentication):
         """ Update the service authentication settings.
@@ -70,11 +70,11 @@ class ServiceAuthentication:
         else:
             if response.status_code == 200:
                 self.logger.info("Service authentication settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelServiceAuthentication.from_dict(response_dict)
-            else:
-                return ModelServiceAuthentication.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelServiceAuthentication.from_dict(response_dict)
+                else:
+                    return ModelServiceAuthentication.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/session.py
+++ b/pingfedsdk/apis/session.py
@@ -49,11 +49,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSessionSettings.from_dict(response_dict)
-            else:
-                return ModelSessionSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSessionSettings.from_dict(response_dict)
+                else:
+                    return ModelSessionSettings.from_dict(response.json())
 
     def updateSessionSettings(self, body: ModelSessionSettings):
         """ Update general session management settings.
@@ -76,11 +76,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("General session management settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSessionSettings.from_dict(response_dict)
-            else:
-                return ModelSessionSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSessionSettings.from_dict(response_dict)
+                else:
+                    return ModelSessionSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -108,11 +108,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelGlobalAuthenticationSessionPolicy.from_dict(response_dict)
-            else:
-                return ModelGlobalAuthenticationSessionPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelGlobalAuthenticationSessionPolicy.from_dict(response_dict)
+                else:
+                    return ModelGlobalAuthenticationSessionPolicy.from_dict(response.json())
 
     def updateGlobalPolicy(self, body: ModelGlobalAuthenticationSessionPolicy):
         """ Update the global authentication session policy.
@@ -135,11 +135,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Global authentication session policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelGlobalAuthenticationSessionPolicy.from_dict(response_dict)
-            else:
-                return ModelGlobalAuthenticationSessionPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelGlobalAuthenticationSessionPolicy.from_dict(response_dict)
+                else:
+                    return ModelGlobalAuthenticationSessionPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -167,11 +167,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApplicationSessionPolicy.from_dict(response_dict)
-            else:
-                return ModelApplicationSessionPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApplicationSessionPolicy.from_dict(response_dict)
+                else:
+                    return ModelApplicationSessionPolicy.from_dict(response.json())
 
     def updateApplicationPolicy(self, body: ModelApplicationSessionPolicy):
         """ Update the application session policy.
@@ -194,11 +194,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Application session policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApplicationSessionPolicy.from_dict(response_dict)
-            else:
-                return ModelApplicationSessionPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApplicationSessionPolicy.from_dict(response_dict)
+                else:
+                    return ModelApplicationSessionPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -226,11 +226,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSessionPolicies.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSessionPolicies.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSessionPolicies.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSessionPolicies.from_dict(response.json())
 
     def createSourcePolicy(self, body: ModelAuthenticationSessionPolicy):
         """ Create a new session policy.
@@ -253,11 +253,11 @@ class Session:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication session policy created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSessionPolicy.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSessionPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSessionPolicy.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSessionPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -285,11 +285,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSessionPolicy.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSessionPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSessionPolicy.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSessionPolicy.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -316,11 +316,11 @@ class Session:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication session policy updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAuthenticationSessionPolicy.from_dict(response_dict)
-            else:
-                return ModelAuthenticationSessionPolicy.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAuthenticationSessionPolicy.from_dict(response_dict)
+                else:
+                    return ModelAuthenticationSessionPolicy.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/sp_adapters.py
+++ b/pingfedsdk/apis/sp_adapters.py
@@ -53,11 +53,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelAction.from_dict(response_dict)
-            else:
-                return ModelAction.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelAction.from_dict(response_dict)
+                else:
+                    return ModelAction.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -84,11 +84,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Action invoked on adapter.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActionResult.from_dict(response_dict)
-            else:
-                return ModelActionResult.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActionResult.from_dict(response_dict)
+                else:
+                    return ModelActionResult.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -114,11 +114,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapterDescriptors.from_dict(response_dict)
-            else:
-                return ModelSpAdapterDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapterDescriptors.from_dict(response_dict)
+                else:
+                    return ModelSpAdapterDescriptors.from_dict(response.json())
 
     def getSpAdapterDescriptorsById(self, id: str):
         """ Get the description of an SP adapter plugin by ID.
@@ -140,11 +140,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapterDescriptor.from_dict(response_dict)
-            else:
-                return ModelSpAdapterDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapterDescriptor.from_dict(response_dict)
+                else:
+                    return ModelSpAdapterDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -170,11 +170,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapters.from_dict(response_dict)
-            else:
-                return ModelSpAdapters.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapters.from_dict(response_dict)
+                else:
+                    return ModelSpAdapters.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -199,11 +199,11 @@ class SpAdapters:
         else:
             if response.status_code == 201:
                 self.logger.info("Adapter created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapter.from_dict(response_dict)
-            else:
-                return ModelSpAdapter.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapter.from_dict(response_dict)
+                else:
+                    return ModelSpAdapter.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -231,11 +231,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapter.from_dict(response_dict)
-            else:
-                return ModelSpAdapter.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapter.from_dict(response_dict)
+                else:
+                    return ModelSpAdapter.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -262,11 +262,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Adapter updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapter.from_dict(response_dict)
-            else:
-                return ModelSpAdapter.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapter.from_dict(response_dict)
+                else:
+                    return ModelSpAdapter.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -326,11 +326,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapterUrlMappings.from_dict(response_dict)
-            else:
-                return ModelSpAdapterUrlMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapterUrlMappings.from_dict(response_dict)
+                else:
+                    return ModelSpAdapterUrlMappings.from_dict(response.json())
 
     def updateUrlMappings(self, body: ModelSpAdapterUrlMappings):
         """ (Deprecated) Update the mappings between URLs and adapters instances.
@@ -353,11 +353,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpAdapterUrlMappings.from_dict(response_dict)
-            else:
-                return ModelSpAdapterUrlMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpAdapterUrlMappings.from_dict(response_dict)
+                else:
+                    return ModelSpAdapterUrlMappings.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -381,11 +381,11 @@ class SpAdapters:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelActions.from_dict(response_dict)
-            else:
-                return ModelActions.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelActions.from_dict(response_dict)
+                else:
+                    return ModelActions.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)

--- a/pingfedsdk/apis/sp_authentication_policy_contract_mappings.py
+++ b/pingfedsdk/apis/sp_authentication_policy_contract_mappings.py
@@ -46,11 +46,11 @@ class SpAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToSpAdapterMappings.from_dict(response_dict)
-            else:
-                return ModelApcToSpAdapterMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToSpAdapterMappings.from_dict(response_dict)
+                else:
+                    return ModelApcToSpAdapterMappings.from_dict(response.json())
 
     def createApcToSpAdapterMapping(self, body: ModelApcToSpAdapterMapping, XBypassExternalValidation: bool = None):
         """ Create a new APC-to-SP Adapter Mapping.
@@ -73,11 +73,11 @@ class SpAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 201:
                 self.logger.info("Authentication policy contract-to-SP adapter mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToSpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelApcToSpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToSpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelApcToSpAdapterMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class SpAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToSpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelApcToSpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToSpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelApcToSpAdapterMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class SpAuthenticationPolicyContractMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Authentication policy contract-to-SP adapter mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelApcToSpAdapterMapping.from_dict(response_dict)
-            else:
-                return ModelApcToSpAdapterMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelApcToSpAdapterMapping.from_dict(response_dict)
+                else:
+                    return ModelApcToSpAdapterMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/sp_default_urls.py
+++ b/pingfedsdk/apis/sp_default_urls.py
@@ -43,11 +43,11 @@ class SpDefaultUrls:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpDefaultUrls.from_dict(response_dict)
-            else:
-                return ModelSpDefaultUrls.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpDefaultUrls.from_dict(response_dict)
+                else:
+                    return ModelSpDefaultUrls.from_dict(response.json())
 
     def updateDefaultUrls(self, body: ModelSpDefaultUrls):
         """ Update the SP Default URLs. Enter values that affect the user's experience when executing SP-initiated SSO operations.
@@ -70,11 +70,11 @@ class SpDefaultUrls:
         else:
             if response.status_code == 200:
                 self.logger.info("Default URL updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpDefaultUrls.from_dict(response_dict)
-            else:
-                return ModelSpDefaultUrls.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpDefaultUrls.from_dict(response_dict)
+                else:
+                    return ModelSpDefaultUrls.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/sp_idp_connections.py
+++ b/pingfedsdk/apis/sp_idp_connections.py
@@ -50,11 +50,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpConnection.from_dict(response_dict)
-            else:
-                return ModelIdpConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpConnection.from_dict(response_dict)
+                else:
+                    return ModelIdpConnection.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -81,11 +81,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpConnection.from_dict(response_dict)
-            else:
-                return ModelIdpConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpConnection.from_dict(response_dict)
+                else:
+                    return ModelIdpConnection.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -145,11 +145,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpConnections.from_dict(response_dict)
-            else:
-                return ModelIdpConnections.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpConnections.from_dict(response_dict)
+                else:
+                    return ModelIdpConnections.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())
 
@@ -174,11 +174,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 201:
                 self.logger.info("Connection created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelIdpConnection.from_dict(response_dict)
-            else:
-                return ModelIdpConnection.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelIdpConnection.from_dict(response_dict)
+                else:
+                    return ModelIdpConnection.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -206,11 +206,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSigningSettings.from_dict(response_dict)
-            else:
-                return ModelSigningSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSigningSettings.from_dict(response_dict)
+                else:
+                    return ModelSigningSettings.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -237,11 +237,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSigningSettings.from_dict(response_dict)
-            else:
-                return ModelSigningSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSigningSettings.from_dict(response_dict)
+                else:
+                    return ModelSigningSettings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -273,11 +273,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConnectionCerts.from_dict(response_dict)
-            else:
-                return ModelConnectionCerts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConnectionCerts.from_dict(response_dict)
+                else:
+                    return ModelConnectionCerts.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -304,11 +304,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 201:
                 self.logger.info("Connection Certificate added.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConnectionCert.from_dict(response_dict)
-            else:
-                return ModelConnectionCert.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConnectionCert.from_dict(response_dict)
+                else:
+                    return ModelConnectionCert.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -341,11 +341,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelConnectionCerts.from_dict(response_dict)
-            else:
-                return ModelConnectionCerts.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelConnectionCerts.from_dict(response_dict)
+                else:
+                    return ModelConnectionCerts.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -377,11 +377,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDecryptionKeys.from_dict(response_dict)
-            else:
-                return ModelDecryptionKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDecryptionKeys.from_dict(response_dict)
+                else:
+                    return ModelDecryptionKeys.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -408,11 +408,11 @@ class SpIdpConnections:
         else:
             if response.status_code == 200:
                 self.logger.info("Connection updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelDecryptionKeys.from_dict(response_dict)
-            else:
-                return ModelDecryptionKeys.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelDecryptionKeys.from_dict(response_dict)
+                else:
+                    return ModelDecryptionKeys.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/sp_target_url_mappings.py
+++ b/pingfedsdk/apis/sp_target_url_mappings.py
@@ -43,11 +43,11 @@ class SpTargetUrlMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpUrlMappings.from_dict(response_dict)
-            else:
-                return ModelSpUrlMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpUrlMappings.from_dict(response_dict)
+                else:
+                    return ModelSpUrlMappings.from_dict(response.json())
 
     def updateUrlMappings(self, body: ModelSpUrlMappings):
         """ Update the mappings between URLs and adapters or connections instances.
@@ -70,11 +70,11 @@ class SpTargetUrlMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelSpUrlMappings.from_dict(response_dict)
-            else:
-                return ModelSpUrlMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelSpUrlMappings.from_dict(response_dict)
+                else:
+                    return ModelSpUrlMappings.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/sp_token_generators.py
+++ b/pingfedsdk/apis/sp_token_generators.py
@@ -48,11 +48,11 @@ class SpTokenGenerators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenGenerator.from_dict(response_dict)
-            else:
-                return ModelTokenGenerator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenGenerator.from_dict(response_dict)
+                else:
+                    return ModelTokenGenerator.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -79,11 +79,11 @@ class SpTokenGenerators:
         else:
             if response.status_code == 200:
                 self.logger.info("Token generator updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenGenerator.from_dict(response_dict)
-            else:
-                return ModelTokenGenerator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenGenerator.from_dict(response_dict)
+                else:
+                    return ModelTokenGenerator.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -143,11 +143,11 @@ class SpTokenGenerators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenGeneratorDescriptors.from_dict(response_dict)
-            else:
-                return ModelTokenGeneratorDescriptors.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenGeneratorDescriptors.from_dict(response_dict)
+                else:
+                    return ModelTokenGeneratorDescriptors.from_dict(response.json())
 
     def getTokenGeneratorDescriptorsById(self, id: str):
         """ Get the description of a token generator plugin by ID.
@@ -169,11 +169,11 @@ class SpTokenGenerators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenGeneratorDescriptor.from_dict(response_dict)
-            else:
-                return ModelTokenGeneratorDescriptor.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenGeneratorDescriptor.from_dict(response_dict)
+                else:
+                    return ModelTokenGeneratorDescriptor.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -199,11 +199,11 @@ class SpTokenGenerators:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenGenerators.from_dict(response_dict)
-            else:
-                return ModelTokenGenerators.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenGenerators.from_dict(response_dict)
+                else:
+                    return ModelTokenGenerators.from_dict(response.json())
 
     def createTokenGenerator(self, body: ModelTokenGenerator):
         """ Create a new token generator instance.
@@ -226,11 +226,11 @@ class SpTokenGenerators:
         else:
             if response.status_code == 201:
                 self.logger.info("Token generator created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenGenerator.from_dict(response_dict)
-            else:
-                return ModelTokenGenerator.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenGenerator.from_dict(response_dict)
+                else:
+                    return ModelTokenGenerator.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/token_processor_to_token_generator_mappings.py
+++ b/pingfedsdk/apis/token_processor_to_token_generator_mappings.py
@@ -46,11 +46,11 @@ class TokenProcessorToTokenGeneratorMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenToTokenMappings.from_dict(response_dict)
-            else:
-                return ModelTokenToTokenMappings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenToTokenMappings.from_dict(response_dict)
+                else:
+                    return ModelTokenToTokenMappings.from_dict(response.json())
 
     def createTokenToTokenMapping(self, body: ModelTokenToTokenMapping, XBypassExternalValidation: bool = None):
         """ Create a new Token Processor to Token Generator Mapping.
@@ -73,11 +73,11 @@ class TokenProcessorToTokenGeneratorMappings:
         else:
             if response.status_code == 201:
                 self.logger.info("Token Processor to Token Generator mapping created.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenToTokenMapping.from_dict(response_dict)
-            else:
-                return ModelTokenToTokenMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenToTokenMapping.from_dict(response_dict)
+                else:
+                    return ModelTokenToTokenMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)
@@ -105,11 +105,11 @@ class TokenProcessorToTokenGeneratorMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenToTokenMapping.from_dict(response_dict)
-            else:
-                return ModelTokenToTokenMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenToTokenMapping.from_dict(response_dict)
+                else:
+                    return ModelTokenToTokenMapping.from_dict(response.json())
             if response.status_code == 404:
                 message = "(404) Resource not found."
                 self.logger.info(message)
@@ -136,11 +136,11 @@ class TokenProcessorToTokenGeneratorMappings:
         else:
             if response.status_code == 200:
                 self.logger.info("Token Processor to Token Generator mapping updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelTokenToTokenMapping.from_dict(response_dict)
-            else:
-                return ModelTokenToTokenMapping.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelTokenToTokenMapping.from_dict(response_dict)
+                else:
+                    return ModelTokenToTokenMapping.from_dict(response.json())
             if response.status_code == 400:
                 message = "(400) The request was improperly formatted or contained invalid fields."
                 self.logger.info(message)

--- a/pingfedsdk/apis/version.py
+++ b/pingfedsdk/apis/version.py
@@ -40,8 +40,8 @@ class Version:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelVersion.from_dict(response_dict)
-            else:
-                return ModelVersion.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelVersion.from_dict(response_dict)
+                else:
+                    return ModelVersion.from_dict(response.json())

--- a/pingfedsdk/apis/virtual_host_names.py
+++ b/pingfedsdk/apis/virtual_host_names.py
@@ -42,11 +42,11 @@ class VirtualHostNames:
         else:
             if response.status_code == 200:
                 self.logger.info("Success.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelVirtualHostNameSettings.from_dict(response_dict)
-            else:
-                return ModelVirtualHostNameSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelVirtualHostNameSettings.from_dict(response_dict)
+                else:
+                    return ModelVirtualHostNameSettings.from_dict(response.json())
 
     def updateVirtualHostNamesSettings(self, body: ModelVirtualHostNameSettings):
         """ Update virtual host names settings.
@@ -69,10 +69,10 @@ class VirtualHostNames:
         else:
             if response.status_code == 200:
                 self.logger.info("Virtual host names settings updated.")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return ModelVirtualHostNameSettings.from_dict(response_dict)
-            else:
-                return ModelVirtualHostNameSettings.from_dict(response.json())
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return ModelVirtualHostNameSettings.from_dict(response_dict)
+                else:
+                    return ModelVirtualHostNameSettings.from_dict(response.json())
             if response.status_code == 422:
                 raise ValidationError(response.json())

--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -66,11 +66,11 @@ class {{ safe_class_name(class_name) }}:
                 raise ValidationError(response.json())
 {% elif response_code["code"] | string in ("200", "201") %}
                 self.logger.info("{{ response_code["message"] }}")
-            if isinstance(response.json(), list):
-                response_dict = {'items': response.json()}
-                return {{ operation.get_response_str(response_code["code"], True) }}
-            else:
-                return {{ operation.get_response_str(response_code["code"]) }}
+                if isinstance(response.json(), list):
+                    response_dict = {'items': response.json()}
+                    return {{ operation.get_response_str(response_code["code"], True) }}
+                else:
+                    return {{ operation.get_response_str(response_code["code"]) }}
 {% elif response_code["code"] | string == "204" %}
                 self.logger.info("{{ response_code["message"] }}")
                 return ModelApiResult(message="{{ response_code["message"] }}", validationErrors=[])


### PR DESCRIPTION
- Commits `75b6e776e0a3d9330e33e1d08f6a013380dbff08`, `e4041d910af05f233ecc2240160d72b10b25d1f7` are just merges from `main` branch (to handle list responses only for 200/201 response codes and not all response codes)
- `e293ae36fc35b1a0c24f3fe04d4d87fa8f844678` is the SDK that was generated with the above fixes
- `2cb80468efdf97591093791a009c4fe3b2e68e7a` are the manual changes for `config_archive.py` to ensure config upload/download continue to work.