### PR TITLE
Patch AccessTokenMappingContext schema

### DIFF
--- a/src/fetch.py
+++ b/src/fetch.py
@@ -373,6 +373,10 @@ class Fetch():
         elif self.swagger_version == "2.0":
             self.server_version = self.get_server_version().split('.')
             self.patch_20_source()
+            self.write_json(
+                data=self.ping_data, name='pf-admin-api-patched',
+                directory="../pingfedsdk/source/"
+            )
             self.logger.info("Getting API schemas for swagger version 2.0")
             self.update_v11_schema()
             self.get_v11_plus_schemas()

--- a/src/patches/v_11/fix_access_token_mapping_context.py
+++ b/src/patches/v_11/fix_access_token_mapping_context.py
@@ -1,0 +1,42 @@
+"""
+Fix Swagger definition of the "AccessTokenMappingContext schema.
+
+The Swagger definition of the "AccessTokenMappingContext" object says that it
+has three attributes - "description", "type" and "contextRef" of which "type"
+and "contextRef" are mandatory.
+
+However, in some cases the API does not return the "contextRef" attribute which
+can cause problems when the generated SDK tries to create
+AccessTokenMappingContext objects from results of an API call.
+
+This behaviour has been observed in 11.1.7 and 11.3.1 and therefore we assume
+is in all v11 versions. If/when it gets fixed in a future 11.x version this
+patch needs to be moved to the respective versions. That can be done in
+multiple ways:
+
+    - Copy this patch file to respective versions.
+        - Not recommended - needless duplication of code
+    - Move this patch file to the lowest version, then in other versions import
+      the relevant functions from the "source" version.
+        - Pythonic fix, OS independent
+    - Move this patch file to the lowest version, then in symlink this to other
+      affected versions.
+        - Simplest fix
+        - OS/Filesystem dependent
+"""
+import logging
+from pathlib import Path
+
+
+PATCH_NAME = Path(__file__).stem
+
+
+def patch(swagger_version: str, input_swagger: dict):
+    if swagger_version != '2.0':
+        logging.warning('%s patch called for swagger version:%s != 2.0, '
+                        'skipping', PATCH_NAME, swagger_version)
+        return
+    models = input_swagger['definitions']
+    target_model = models['AccessTokenMappingContext']
+    required_properties = target_model['required']
+    required_properties.remove('contextRef')


### PR DESCRIPTION
The AccessTokenMappingContext schema and the actual results returned by the API calls do not match - the "contextRef" attribute was stated to be mandatory by the schema but not returned by the API calls (at least) in some circumstances, thereby leading to an error if the generated SDK was used to build an AccessTokenMappingContext object from the results of such an API call.