### PR TITLE
Schema patches for some models

### DIFF
--- a/src/fetch.py
+++ b/src/fetch.py
@@ -373,6 +373,10 @@ class Fetch():
         elif self.swagger_version == "2.0":
             self.server_version = self.get_server_version().split('.')
             self.patch_20_source()
+            self.write_json(
+                data=self.ping_data, name='pf-admin-api-patched',
+                directory="../pingfedsdk/source/"
+            )
             self.logger.info("Getting API schemas for swagger version 2.0")
             self.update_v11_schema()
             self.get_v11_plus_schemas()

--- a/src/patches/v_11/fix_artifact_settings.py
+++ b/src/patches/v_11/fix_artifact_settings.py
@@ -1,0 +1,50 @@
+"""
+Fix Swagger schema of the "ArtifactSettings" model.
+
+The Swagger definition of the "ArtifactSettings" model says that the "lifetime"
+and "resolverLocations" attribute are mandatory. However, the documentation
+from Ping support page
+(https://docs.pingidentity.com/r/en-us/pingfederate-112/help_idpprotocolsettingstasklet_configartifactlifetimestate)
+says: that "lifetime" attribute has a default of 60 seconds, i.e. it is
+optional.
+
+It has been observed that for some configurations the "lifetime" attribute is
+not set in an API response which causes the instantiation of the corresponding
+ArtifactSettings instance to fail.
+
+Since the Swagger definition of the "ArtifactSettings" model in the latest
+PingFederate release as of the date of writing this code (11.3.2.0) still
+specifies it as mandatory it is assumed to be present in all v11 versions.
+If/when it gets fixed in a future 11.x version this patch needs to be moved to
+the respective versions. That can be done in multiple ways:
+
+    - Copy this patch file to respective versions.
+        - Not recommended - needless duplication of code
+    - Move this patch file to the lowest version, then in other versions import
+      the relevant functions from the "source" version.
+        - Pythonic fix, OS independent
+    - Move this patch file to the lowest version, then in symlink this to other
+      affected versions.
+        - Simplest fix
+        - OS/Filesystem dependent
+
+This patch changes the spec for the "ArtifactSettings" model to make the
+"lifetime" attribute optional.
+"""
+import logging
+from pathlib import Path
+
+
+PATCH_NAME = Path(__file__).stem
+
+
+def patch(swagger_version: str, input_swagger: dict):
+    if swagger_version != '2.0':
+        logging.warning(
+            '%s patch called for swagger version:%s != 2.0, skipping',
+            PATCH_NAME, swagger_version
+        )
+        return
+    artifact_settings_model = input_swagger['definitions']['ArtifactSettings']
+    model_required_list = artifact_settings_model['required']
+    model_required_list.remove("lifetime")

--- a/src/patches/v_11/fix_attribute_fulfillment_value.py
+++ b/src/patches/v_11/fix_attribute_fulfillment_value.py
@@ -1,0 +1,43 @@
+"""
+Fix Swagger schema of the "AttributeFulfillmentValue" model.
+
+The Swagger definition of the "AttributeFulfillmentValue" model says that the
+"value" attribute is mandatory. However when the corresponding "source.type"
+value is "NO_MAPPING" the value is null/not required.
+
+Since the Swagger definition of the "AttributeFulfillmentValue" model in the
+latest PingFederate release as of the date of writing this code (11.3.2.0)
+still specifies it as mandatory it is assumed to be present in all v11
+versions. If/when it gets fixed in a future 11.x version this patch needs to be
+moved to the respective versions. That can be done in multiple ways:
+
+    - Copy this patch file to respective versions.
+        - Not recommended - needless duplication of code
+    - Move this patch file to the lowest version, then in other versions import
+      the relevant functions from the "source" version.
+        - Pythonic fix, OS independent
+    - Move this patch file to the lowest version, then in symlink this to other
+      affected versions.
+        - Simplest fix
+        - OS/Filesystem dependent
+
+This patch changes the spec for the "AttributeFulfillmentValue" model to make
+the "value" attribute optional.
+"""
+import logging
+from pathlib import Path
+
+
+PATCH_NAME = Path(__file__).stem
+
+
+def patch(swagger_version: str, input_swagger: dict):
+    if swagger_version != '2.0':
+        logging.warning(
+            '%s patch called for swagger version:%s != 2.0, skipping',
+            PATCH_NAME, swagger_version
+        )
+        return
+    artifact_settings_model = input_swagger['definitions']['AttributeFulfillmentValue']
+    model_required_list = artifact_settings_model['required']
+    model_required_list.remove("value")

--- a/src/patches/v_11/fix_sp_browser_sso.py
+++ b/src/patches/v_11/fix_sp_browser_sso.py
@@ -1,0 +1,46 @@
+"""
+Fix Swagger schema of the "SpBrowserSso" model.
+
+The Swagger definition of the "SpBrowserSso" model says that the
+"encryptionPolicy" attribute is mandatory. However the documentation for the
+encryptionPolicy attribute says that:
+
+    > The SAML 2.0 encryption policy for browser-based SSO. Required for SAML
+    > 2.0 connections.
+
+Since the Swagger definition of the "SpBrowserSso" model in the
+latest PingFederate release as of the date of writing this code (11.3.2.0)
+still specifies it as mandatory it is assumed to be present in all v11
+versions. If/when it gets fixed in a future 11.x version this patch needs to be
+moved to the respective versions. That can be done in multiple ways:
+
+    - Copy this patch file to respective versions.
+        - Not recommended - needless duplication of code
+    - Move this patch file to the lowest version, then in other versions import
+      the relevant functions from the "source" version.
+        - Pythonic fix, OS independent
+    - Move this patch file to the lowest version, then in symlink this to other
+      affected versions.
+        - Simplest fix
+        - OS/Filesystem dependent
+
+This patch changes the spec for the "SpBrowserSso" model to make
+the "encryptionPolicy" attribute optional.
+"""
+import logging
+from pathlib import Path
+
+
+PATCH_NAME = Path(__file__).stem
+
+
+def patch(swagger_version: str, input_swagger: dict):
+    if swagger_version != '2.0':
+        logging.warning(
+            '%s patch called for swagger version:%s != 2.0, skipping',
+            PATCH_NAME, swagger_version
+        )
+        return
+    artifact_settings_model = input_swagger['definitions']['SpBrowserSso']
+    model_required_list = artifact_settings_model['required']
+    model_required_list.remove("encryptionPolicy")

--- a/src/patches/v_11/fix_sp_browser_sso_attribute.py
+++ b/src/patches/v_11/fix_sp_browser_sso_attribute.py
@@ -1,0 +1,51 @@
+"""
+Fix Swagger schema of the "SpBrowserSsoAttribute" model.
+
+The Swagger definition of the "SpBrowserSsoAttribute" model (which is used for
+definining both "core" as well as "extended" attributes of
+"SpBrowserSsoAttributeContract") says that the "nameFormat" attribute is
+mandatory. However there are cases where it is not returned by an API call - in
+those cases it is always a core attribute in question because the name format
+of core attributes are specified by the SAML spec and therefore are not needed.
+Besides, no APIs allow modification of the core attributes - only extended
+attributes can be modified and for them the "nameFormat" attribute is required.
+Unfortunately since the Swagger definition uses the same model for both core
+and extended attributes the nameFormat attribute must be made optional to
+accomodate for core attributes not returning the "nameFormat" attribute.
+
+Since the Swagger definition of the "SpBrowserSsoAttribute" model in the latest
+PingFederate release as of the date of writing this code (11.3.2.0) still
+specifies it as mandatory it is assumed to be present in all v11 versions.
+If/when it gets fixed in a future 11.x version this patch needs to be moved to
+the respective versions. That can be done in multiple ways:
+
+    - Copy this patch file to respective versions.
+        - Not recommended - needless duplication of code
+    - Move this patch file to the lowest version, then in other versions import
+      the relevant functions from the "source" version.
+        - Pythonic fix, OS independent
+    - Move this patch file to the lowest version, then in symlink this to other
+      affected versions.
+        - Simplest fix
+        - OS/Filesystem dependent
+
+This patch changes the spec for the "SpBrowserSsoAttribute" model to make the
+"nameFormat" attribute optional.
+"""
+import logging
+from pathlib import Path
+
+
+PATCH_NAME = Path(__file__).stem
+
+
+def patch(swagger_version: str, input_swagger: dict):
+    if swagger_version != '2.0':
+        logging.warning(
+            '%s patch called for swagger version:%s != 2.0, skipping',
+            PATCH_NAME, swagger_version
+        )
+        return
+    artifact_settings_model = input_swagger['definitions']['SpBrowserSsoAttribute']
+    model_required_list = artifact_settings_model['required']
+    model_required_list.remove("nameFormat")

--- a/src/patches/v_11/fix_sp_sso_service_endpoint.py
+++ b/src/patches/v_11/fix_sp_sso_service_endpoint.py
@@ -1,0 +1,53 @@
+"""
+Fix Swagger schema of the "SpSsoServiceEndpoint" model.
+
+The Swagger definition of the "SpSsoServiceEndpoint" model says that the
+"binding" and "index" attributes are mandatory. However the description for the
+"binding" attribute says that it is usually only required for SAML 2.0
+endpoints.
+
+There are cases where the APIs don't return "binding" attribute for an
+SpSsoServiceEndpoint object causing a problem when the generated code tries to
+convert the response to an SpSsoServiceEndpoint object. Additionally, due to
+the nature of the "index' attribute, it is not required for an endpoint for
+which "isDefault" is true.
+
+See: https://docs.pingidentity.com/r/en-us/pingfederate-102/idp_endpoints
+
+Since the Swagger definition of the "SpSsoServiceEndpoint" model in the latest
+PingFederate release as of the date of writing this code (11.3.2.0) still
+specifies it as mandatory it is assumed to be present in all v11 versions.
+If/when it gets fixed in a future 11.x version this patch needs to be moved to
+the respective versions. That can be done in multiple ways:
+
+    - Copy this patch file to respective versions.
+        - Not recommended - needless duplication of code
+    - Move this patch file to the lowest version, then in other versions import
+      the relevant functions from the "source" version.
+        - Pythonic fix, OS independent
+    - Move this patch file to the lowest version, then in symlink this to other
+      affected versions.
+        - Simplest fix
+        - OS/Filesystem dependent
+
+This patch changes the spec for the "SpSsoServiceEndpoint" model to make the
+"binding" and "index" attributes optional.
+"""
+import logging
+from pathlib import Path
+
+
+PATCH_NAME = Path(__file__).stem
+
+
+def patch(swagger_version: str, input_swagger: dict):
+    if swagger_version != '2.0':
+        logging.warning(
+            '%s patch called for swagger version:%s != 2.0, skipping',
+            PATCH_NAME, swagger_version
+        )
+        return
+    artifact_settings_model = input_swagger['definitions']['SpSsoServiceEndpoint']
+    model_required_list = artifact_settings_model['required']
+    model_required_list.remove("binding")
+    model_required_list.remove("index")

--- a/src/patches/v_11/fix_sp_ws_trust_attribute.py
+++ b/src/patches/v_11/fix_sp_ws_trust_attribute.py
@@ -1,0 +1,46 @@
+"""
+Fix Swagger schema of the "SpWsTrustAttribute" model.
+
+The Swagger definition of the "SpWsTrustAttribute" model says that the
+"namespace" attribute is mandatory. However the documentation for the
+"namespace" attribute says that:
+
+    > This is required when the Default Token Type is SAML2.0 or SAML1.1 or
+    > SAML1.1 for Office 365.
+
+Since the Swagger definition of the "SpWsTrustAttribute" model in the
+latest PingFederate release as of the date of writing this code (11.3.2.0)
+still specifies it as mandatory it is assumed to be present in all v11
+versions. If/when it gets fixed in a future 11.x version this patch needs to be
+moved to the respective versions. That can be done in multiple ways:
+
+    - Copy this patch file to respective versions.
+        - Not recommended - needless duplication of code
+    - Move this patch file to the lowest version, then in other versions import
+      the relevant functions from the "source" version.
+        - Pythonic fix, OS independent
+    - Move this patch file to the lowest version, then in symlink this to other
+      affected versions.
+        - Simplest fix
+        - OS/Filesystem dependent
+
+This patch changes the spec for the "SpWsTrustAttribute" model to make
+the "namespace" attribute optional.
+"""
+import logging
+from pathlib import Path
+
+
+PATCH_NAME = Path(__file__).stem
+
+
+def patch(swagger_version: str, input_swagger: dict):
+    if swagger_version != '2.0':
+        logging.warning(
+            '%s patch called for swagger version:%s != 2.0, skipping',
+            PATCH_NAME, swagger_version
+        )
+        return
+    artifact_settings_model = input_swagger['definitions']['SpWsTrustAttribute']
+    model_required_list = artifact_settings_model['required']
+    model_required_list.remove("namespace")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -239,6 +239,9 @@ class TestGenerate(TestCase):
         penguins = __import__("pingfedsdk.apis.penguins", fromlist=[""])
         penguin = __import__("pingfedsdk.models.penguin", fromlist=[""])
         session_mock = MagicMock()
+        post_response = MagicMock(status_code=200)
+        post_response.json.return_value = self.penguin_dict
+        session_mock.post.return_value = post_response
         penguin_api = penguins.Penguins("test-endpoint", session_mock)
         self.assertEqual(
             penguin_api.addPenguin(penguin.Penguin().from_dict(
@@ -247,6 +250,8 @@ class TestGenerate(TestCase):
             penguin_mock.from_dict.return_value
         )
 
+        get_response = MagicMock(status_code=200)
+        session_mock.get.return_value = get_response
         self.assertEqual(
             penguin_api.getPenguinDetails(),
             penguin_mock.from_dict.return_value


### PR DESCRIPTION
The Swagger schema for the following models need patching:
    - ArtifactSettings
    - AttributeFulfillmentValue
    - SpBrowserSso
    - SpBrowserSsoAttribute
    - SpSsoServiceEndpoint
    - SpWsTrustAttribute

Details about the reasons are in the docstring in the respective patch files.

With these changes the manually applied (and incorrect) changes to the generated SDK in the following commits should be removed:
    - a962972f6b54626f7b345513905dd44ef301dc4b
    - 56655675b042f5b241fe9bb370a043e1d91b78dc

The fetcher has also been changed to save patched Swagger schemas so that it is easy to compare the state of the Swagger schemas before and after patching.

Also fix failing unit test.